### PR TITLE
feat(enrichment): add require_attributes config toggle

### DIFF
--- a/_bmad-output/implementation-artifacts/1-1-add-require-attributes-config-toggle.md
+++ b/_bmad-output/implementation-artifacts/1-1-add-require-attributes-config-toggle.md
@@ -1,0 +1,164 @@
+# Story 1.1: Add `require_attributes` Config Toggle
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a developer,
+I want a `require-attributes` boolean toggle in `[tool.docvet.enrichment]`,
+so that teams can enable or disable Attributes checking for classes independently.
+
+## Acceptance Criteria
+
+1. **Given** an `EnrichmentConfig` with no explicit `require-attributes` setting, **when** the config is loaded from `pyproject.toml`, **then** `require_attributes` defaults to `True` (AC: #1)
+
+2. **Given** a `pyproject.toml` with `require-attributes = false` under `[tool.docvet.enrichment]`, **when** the config is loaded, **then** `require_attributes` is `False` (AC: #2)
+
+3. **Given** an existing `pyproject.toml` without a `require-attributes` key, **when** the config is loaded, **then** all existing config fields retain their values and no error is raised (backward-compatible) (AC: #3)
+
+4. **Given** the `_VALID_ENRICHMENT_KEYS` set in `config.py`, **when** inspected, **then** it includes `"require-attributes"` (AC: #4)
+
+5. **Given** the `_parse_enrichment` function, **when** it receives an unknown key (e.g., `require-foo = true`), **then** it rejects the key at config load time with a clear error message (AC: #5)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add `require_attributes: bool = True` field to `EnrichmentConfig` dataclass (AC: #1, #3)
+  - [x] 1.1: Add the field after `prefer_fenced_code_blocks` in `EnrichmentConfig`
+- [x] Task 2: Add `"require-attributes"` to `_VALID_ENRICHMENT_KEYS` frozenset (AC: #4, #5)
+  - [x] 2.1: Insert the key into the existing frozenset in alphabetical position relative to other `require-*` keys
+- [x] Task 3: Write unit tests for the new config toggle (AC: #1, #2, #3, #4, #5)
+  - [x] 3.1: `test_enrichment_defaults_require_attributes_is_true` — default value test
+  - [x] 3.2: `test_load_config_nested_enrichment_require_attributes_false` — explicit `false` parsed correctly
+  - [x] 3.3: `test_load_config_nested_enrichment_without_require_attributes_uses_default` — backward compatibility (omitted key keeps default)
+  - [x] 3.4: Verify existing unknown-key test still passes (covers AC #5 via existing `test_load_config_unknown_enrichment_key_exits`)
+- [x] Task 4: Run quality gates and verify all pass
+  - [x] 4.1: `uv run ruff check .`
+  - [x] 4.2: `uv run ruff format --check .`
+  - [x] 4.3: `uv run ty check`
+  - [x] 4.4: `uv run pytest --cov=docvet --cov-report=term-missing`
+
+## Dev Notes
+
+### Scope
+
+This is **Prerequisite PR 1** of the enrichment module. It is intentionally minimal — a single new field on an existing frozen dataclass plus a key added to an existing validation set. No new files created.
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/docvet/config.py` | Add `require_attributes: bool = True` to `EnrichmentConfig`; add `"require-attributes"` to `_VALID_ENRICHMENT_KEYS` |
+| `tests/unit/test_config.py` | Add 3 new tests for the toggle |
+
+### Architecture Constraints
+
+- `EnrichmentConfig` is a `@dataclass(frozen=True)` — new field must have a default value for backward compatibility (NFR19)
+- `_VALID_ENRICHMENT_KEYS` is a `frozenset[str]` using kebab-case keys — the new key must be `"require-attributes"` (kebab-case)
+- `_parse_enrichment()` already handles boolean validation for all non-`require-examples` keys via the `else` branch — no parser changes needed, the new key is automatically validated as `bool`
+- The existing `_validate_keys()` call in `_parse_enrichment()` ensures unknown keys are rejected — AC #5 is covered by the existing validation mechanism once the key is added to the valid set
+
+### Implementation Details
+
+**`EnrichmentConfig` field placement:** Add `require_attributes: bool = True` as the last boolean field before the class closes. Current field order:
+1. `require_examples` (list)
+2. `require_raises` through `prefer_fenced_code_blocks` (9 booleans)
+3. **NEW:** `require_attributes: bool = True`
+
+**Why no `_parse_enrichment` changes:** The function iterates `data.items()` and for any key that isn't `"require-examples"`, it validates the value as `bool` then converts kebab-to-snake. Since `"require-attributes"` is a standard boolean toggle, the existing parsing logic handles it automatically after the key is added to `_VALID_ENRICHMENT_KEYS`.
+
+**Test naming convention:** Follow existing pattern in `test_config.py`:
+- `test_enrichment_defaults_require_attributes_is_true` (matches `test_enrichment_defaults_require_raises_is_true` pattern)
+- `test_load_config_nested_enrichment_require_attributes_false` (matches `test_load_config_nested_enrichment_flipped_booleans` pattern)
+
+### What NOT to Do
+
+- Do NOT modify `_parse_enrichment()` logic — it already handles boolean keys generically
+- Do NOT add a new section parser or validation function
+- Do NOT modify `cli.py` or any other file — this is config-only
+- Do NOT add `require_attributes` to `DocvetConfig` — it belongs in `EnrichmentConfig`
+- Do NOT change the frozen dataclass to mutable
+
+### Testing Strategy
+
+- **Unit tests only** — no integration tests needed for a config field addition
+- Use existing `write_pyproject` fixture pattern from `test_config.py`
+- Existing tests must continue passing unchanged (backward compatibility proof)
+- Existing `test_load_config_unknown_enrichment_key_exits` already covers unknown key rejection (AC #5)
+- Existing `test_enrichment_when_mutated_raises_frozen_error` covers frozen enforcement
+
+### FRs Covered
+
+- FR26: Per-rule boolean config toggles (the `require-attributes` toggle)
+- FR29: Disable all findings via config (contributes — all toggles must exist)
+- FR30: Sensible defaults when no config provided (`require_attributes=True`)
+- NFR19: Backward-compatible config addition
+
+### Project Structure Notes
+
+- No new files — modifications to 2 existing files only
+- `src/docvet/config.py` is the single source of truth for all configuration
+- `tests/unit/test_config.py` mirrors the config module
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/architecture.md#Prerequisite PRs] — "Prereq PR 1: Add `require_attributes: bool = True` to `EnrichmentConfig`, update `_VALID_ENRICHMENT_KEYS`, update `_parse_enrichment` validation, update affected tests"
+- [Source: _bmad-output/planning-artifacts/architecture.md#Config Schema Update] — "New toggle needed: `require-attributes: bool = True`"
+- [Source: _bmad-output/planning-artifacts/prd.md#Config Schema Update] — "Updated EnrichmentConfig (10 booleans + 1 list)"
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 1.1] — BDD acceptance criteria
+- [Source: _bmad-output/project-context.md#Python Language Rules] — "Every file starts with `from __future__ import annotations`"
+- [Source: _bmad-output/project-context.md#Testing Rules] — Test naming convention and self-contained test requirements
+- [Source: src/docvet/config.py:24-38] — Current `EnrichmentConfig` definition
+- [Source: src/docvet/config.py:79-91] — Current `_VALID_ENRICHMENT_KEYS` definition
+- [Source: src/docvet/config.py:257-277] — Current `_parse_enrichment` function
+- [Source: tests/unit/test_config.py] — Existing test patterns to follow
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+No issues encountered. All tasks completed in a single pass.
+
+### Completion Notes List
+
+- Added `require_attributes: bool = True` as the last field in `EnrichmentConfig` dataclass (after `prefer_fenced_code_blocks`)
+- Added `"require-attributes"` to `_VALID_ENRICHMENT_KEYS` frozenset in alphabetical position among `require-*` keys
+- No changes needed to `_parse_enrichment()` — existing generic boolean parsing handles the new key automatically
+- Added 3 new unit tests following existing naming conventions
+- Verified existing `test_load_config_unknown_enrichment_key_exits` still passes (AC #5 coverage)
+- All 190 tests pass, 98% coverage, all quality gates green
+
+### Change Log
+
+- 2026-02-08: Implemented story 1-1 — added `require_attributes` config toggle to `EnrichmentConfig` with 3 new unit tests
+- 2026-02-08: Code review — fixed 2 issues: updated `test_load_config_full_config_populates_all_fields` to cover `require-attributes`, sorted `_VALID_ENRICHMENT_KEYS` alphabetically
+
+### File List
+
+- `src/docvet/config.py` (modified) — added `require_attributes: bool = True` field; added `"require-attributes"` valid key; sorted `_VALID_ENRICHMENT_KEYS` alphabetically
+- `tests/unit/test_config.py` (modified) — added 3 new tests for default value, explicit false, and backward compatibility; updated full-config test to cover `require-attributes`
+
+## Senior Developer Review (AI)
+
+**Review Date:** 2026-02-08
+**Reviewer:** Claude Opus 4.6 (code-review workflow)
+**Outcome:** Approve (with fixes applied)
+
+### Findings Summary
+
+| # | Severity | Description | Resolution |
+|---|----------|-------------|------------|
+| 1 | MEDIUM | `test_load_config_full_config_populates_all_fields` did not exercise `require-attributes` | Fixed — added TOML key and assertion |
+| 2 | MEDIUM | Excessive/disordered git commits (5 commits for trivial change) | Deferred — user will squash on merge |
+| 3 | LOW | No explicit `require-attributes = true` TOML test | Accepted — default path covers this |
+| 4 | LOW | Field placed after `prefer_fenced_code_blocks` breaks `require_*` grouping | Accepted — matches Dev Notes spec |
+| 5 | LOW | `_VALID_ENRICHMENT_KEYS` not alphabetically sorted | Fixed — sorted all keys alphabetically |
+
+### AC Verification
+
+All 5 Acceptance Criteria verified as IMPLEMENTED with runtime confirmation and passing tests.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,0 +1,64 @@
+# generated: 2026-02-08
+# project: docvet
+# project_key: NOKEY
+# tracking_system: file-system
+# story_location: _bmad-output/implementation-artifacts
+
+# STATUS DEFINITIONS:
+# ==================
+# Epic Status:
+#   - backlog: Epic not yet started
+#   - in-progress: Epic actively being worked on
+#   - done: All stories in epic completed
+#
+# Epic Status Transitions:
+#   - backlog → in-progress: Automatically when first story is created (via create-story)
+#   - in-progress → done: Manually when all stories reach 'done' status
+#
+# Story Status:
+#   - backlog: Story only exists in epic file
+#   - ready-for-dev: Story file created in stories folder
+#   - in-progress: Developer actively working on implementation
+#   - review: Ready for code review (via Dev's code-review workflow)
+#   - done: Story completed
+#
+# Retrospective Status:
+#   - optional: Can be completed but not required
+#   - done: Retrospective has been completed
+#
+# WORKFLOW NOTES:
+# ===============
+# - Epic transitions to 'in-progress' automatically when first story is created
+# - Stories can be worked in parallel if team capacity allows
+# - SM typically creates next story after previous one is 'done' to incorporate learnings
+# - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
+
+generated: 2026-02-08
+project: docvet
+project_key: NOKEY
+tracking_system: file-system
+story_location: _bmad-output/implementation-artifacts
+
+development_status:
+  # Epic 1: Function-Level Enrichment Detection
+  epic-1: in-progress
+  1-1-add-require-attributes-config-toggle: done
+  1-2-create-finding-dataclass: backlog
+  1-3-section-header-parser-and-node-index: backlog
+  1-4-missing-raises-detection-and-orchestrator: backlog
+  1-5-missing-yields-and-receives-detection: backlog
+  1-6-missing-warns-and-other-parameters-detection: backlog
+  1-7-cli-wiring-for-enrichment-check: backlog
+  epic-1-retrospective: optional
+
+  # Epic 2: Class & Module Enrichment Detection
+  epic-2: backlog
+  2-1-dataclass-namedtuple-and-typeddict-attributes-detection: backlog
+  2-2-plain-class-and-init-py-module-attributes-detection: backlog
+  epic-2-retrospective: optional
+
+  # Epic 3: Format & Recommended Rules
+  epic-3: backlog
+  3-1-missing-examples-detection: backlog
+  3-2-format-and-cross-reference-rules: backlog
+  epic-3-retrospective: optional

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -1,0 +1,733 @@
+---
+stepsCompleted:
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 7
+  - 8
+lastStep: 8
+status: 'complete'
+completedAt: '2026-02-08'
+inputDocuments:
+  - '_bmad-output/planning-artifacts/prd.md'
+  - '_bmad-output/planning-artifacts/prd-validation-report.md'
+  - '_bmad-output/project-context.md'
+  - 'docs/index.md'
+  - 'docs/architecture.md'
+  - 'docs/product-vision.md'
+  - 'docs/project-overview.md'
+  - 'docs/development-guide.md'
+  - 'docs/source-tree-analysis.md'
+workflowType: 'architecture'
+project_name: 'docvet'
+user_name: 'Alberto-Codes'
+date: '2026-02-08'
+---
+
+# Architecture Decision Document
+
+_This document builds collaboratively through step-by-step discovery. Sections are appended as we work through each architectural decision together._
+
+## Project Context Analysis
+
+### Requirements Overview
+
+**Functional Requirements:**
+42 FRs across 6 categories. The enrichment module is a single pure function that detects 14 scenarios (mapped to 10 rule identifiers) by combining AST node inspection with docstring section header matching. Key architectural groupings:
+
+- **Section Detection (FR1-FR15):** 15 FRs defining what to detect — each maps to an AST pattern + docstring section check
+- **Finding Production (FR16-FR22):** 7 FRs defining output shape — `Finding` dataclass, deduplication, zero-finding guarantees
+- **Rule Management (FR23-FR25):** 3 FRs defining stable kebab-case identifiers and scenario-to-rule mapping
+- **Configuration (FR26-FR31):** 6 FRs defining toggle behavior — 10 booleans + 1 list, defaults, validation
+- **Symbol Analysis (FR32-FR38):** 7 FRs defining input processing — AST traversal, docstring parsing, graceful degradation
+- **Integration (FR39-FR42):** 4 FRs defining the public API contract — pure function, shared `Finding` type, CLI wiring
+
+**Non-Functional Requirements:**
+19 NFRs across 5 categories that directly shape internal architecture:
+
+- **Performance (NFR1-4):** Sub-50ms per file, linear memory scaling, no cross-file state — enforces stateless per-file processing
+- **Correctness (NFR5-9):** Zero false positives, deterministic output, crash-proof on malformed input — enforces defensive parsing with fail-safe defaults
+- **Maintainability (NFR10-13):** Rule independence, 3-file change ceiling for new rules, 90% coverage target — enforces modular rule structure
+- **Compatibility (NFR14-16):** Python 3.12/3.13, cross-platform, no new deps — eliminates platform-conditional code paths
+- **Integration (NFR17-19):** Frozen `Finding` shape, existing stub wiring, backward-compatible config — constrains API surface
+
+**Scale & Complexity:**
+
+- Primary domain: CLI developer tool (single-process, file-at-a-time)
+- Complexity level: Medium
+- Estimated architectural components: ~5 internal components (section parser, rule dispatcher, symbol analyzer, finding builder, config responder)
+
+### Rule Complexity Tiering
+
+The 10 rules vary significantly in architectural complexity. This tiering informs implementation sequencing and risk allocation:
+
+| Tier | Rules | Characteristics |
+|------|-------|----------------|
+| **High** | `missing-attributes` | 5 detection branches (plain class, dataclass, NamedTuple, TypedDict, `__init__.py` module), deduplication required, needs AST + docstring + file_path context |
+| **Medium** | `missing-raises`, `missing-yields`, `missing-receives`, `missing-warns` | AST body/expression inspection + docstring section presence check |
+| **Low** | `missing-other-parameters`, `missing-examples`, `missing-cross-references`, `missing-typed-attributes`, `prefer-fenced-code-blocks` | Straightforward pattern match on AST signature or docstring content only |
+
+### Rule Input Dependency Categories
+
+Rules fall into three categories based on what inputs they inspect. These categories are not mutually exclusive — `missing-attributes` spans all three.
+
+- **AST + docstring rules:** Inspect AST nodes (raise statements, yield expressions, warn calls, kwargs, class fields) and check for corresponding docstring section presence. Rules: `missing-raises`, `missing-yields`, `missing-receives`, `missing-warns`, `missing-other-parameters`, `missing-attributes`, `missing-examples`
+- **Docstring-only rules:** Inspect docstring content/format without AST inspection. Rules: `missing-typed-attributes`, `prefer-fenced-code-blocks`, `missing-cross-references`
+- **Context-aware rules:** Branch on `file_path.endswith("__init__.py")` for module-level special handling. Rules: `missing-attributes`, `missing-examples`, `missing-cross-references`
+
+### Shared Infrastructure: Section Header Parsing
+
+Section header parsing is architecturally load-bearing — every rule depends on knowing which sections are present in a docstring. This must be centralized as a shared internal function (`_parse_sections(docstring: str) -> set[str]`) within `enrichment.py` (not `ast_utils.py`, since section parsing is enrichment-specific). Called once per symbol, the result is passed to each rule checker. This prevents subtle inconsistencies between rules and is a prerequisite for NFR11's 3-file change ceiling to hold.
+
+Recognized headers (8 for detection + 2 for context): `Raises:`, `Yields:`, `Receives:`, `Warns:`, `Other Parameters:`, `Attributes:`, `Examples:`, `See Also:`, plus `Args:` and `Returns:` recognized but not checked for absence.
+
+### AST Boundary Decision
+
+The existing `Symbol` dataclass provides: `name`, `kind`, `line`, `docstring`, `parent`, `signature_range`, `body_range`. This is sufficient for **symbol-level metadata** but **not for body-level inspection**. Rules like `missing-raises`, `missing-yields`, `missing-receives`, and `missing-warns` need to inspect AST nodes *inside* function bodies (raise statements, yield expressions, `warnings.warn()` calls).
+
+**Position:** `check_enrichment` receives the full `ast.Module` tree and re-walks relevant nodes locally. `Symbol` stays lightweight — it identifies *which* symbols to check and provides their docstrings. The enrichment module performs its own targeted AST inspection for body-level patterns. This keeps `ast_utils.py` general-purpose and avoids bloating `Symbol` with enrichment-specific fields.
+
+### `missing-attributes` Dispatch Order
+
+The `missing-attributes` rule has 5 detection branches. To satisfy FR18 (at most one finding per symbol per rule), branches are evaluated in **priority order with first-match-wins semantics — no fallthrough**:
+
+1. Dataclass (decorator inspection)
+2. NamedTuple (base class inspection)
+3. TypedDict (base class inspection)
+4. Plain class with `__init__` self-assignments
+5. `__init__.py` module-level exports
+
+This ordering is an **architectural constraint**, not an implementation detail. It ensures deterministic, predictable deduplication regardless of how the code is structured.
+
+### Technical Constraints & Dependencies
+
+- **Existing infrastructure:** `Symbol` dataclass (frozen, with `kind`, `docstring`, `line`, `parent` fields), `get_documented_symbols()` flat list, `EnrichmentConfig` with 10 booleans + 1 list
+- **`file_path` parameter:** Required for `__init__.py` detection — 3 rules branch on this
+- **Caller provides AST:** `check_enrichment` does not call `ast.parse()` — SyntaxError handling is the caller's responsibility
+- **Google-style only:** Section headers are a fixed set of 8+2 strings
+- **No cross-check imports:** `checks/enrichment.py` depends only on `checks.Finding` and `ast_utils`
+- **Config schema:** `require-attributes: bool = True` is a new toggle (prerequisite PR)
+
+### Cross-Cutting Concerns Identified
+
+- **Config toggle respect:** Every rule must check its corresponding config toggle before producing findings — disabled rules produce zero findings unconditionally
+- **No-docstring skip:** All rules skip symbols with no docstring (FR20, FR37) — presence checking is interrogate's domain
+- **Malformed docstring resilience:** All rules must handle broken indentation, missing colons, and non-standard headers without crashing (NFR7, FR38) — `_parse_sections()` returns empty set on unparseable input
+- **One-finding-per-symbol-per-rule deduplication:** Enforced structurally by the dispatch pattern (first-match-wins for `missing-attributes`) and by the rule-per-symbol iteration model for all other rules
+
+## Existing Infrastructure Inventory
+
+### Primary Technology Domain
+
+**CLI tool / developer tooling** — Python single-process pipeline. Brownfield project (`projectType: cli_tool`, `projectContext: brownfield`). All foundational technology decisions are implemented, tested, and CI-enforced.
+
+### Infrastructure the Enrichment Module Depends On
+
+**`ast_utils.py` — Symbol Extraction:**
+- `get_documented_symbols(source: str, tree: ast.Module) -> list[Symbol]` — the only `ast_utils` function enrichment calls
+- Returns flat list of `Symbol` objects (frozen dataclass) with: `name`, `kind` (`"function" | "class" | "method" | "module"`), `line`, `end_line`, `docstring`, `parent` (enclosing class name or `None`)
+- Enrichment iterates this list, skipping symbols with no docstring (FR20, FR37)
+
+**`config.py` — EnrichmentConfig:**
+
+Current state (9 booleans + 1 list):
+- `require_raises`, `require_yields`, `require_receives`, `require_warns`, `require_other_parameters`, `require_typed_attributes`, `require_cross_references`, `prefer_fenced_code_blocks` (booleans)
+- `require_examples` (list of symbol type strings)
+
+Post-prerequisite PR (10 booleans + 1 list):
+- Adds `require_attributes: bool = True` — controls the `missing-attributes` rule
+- Backward-compatible: new field with default value, no existing config breaks
+
+**`cli.py` — Stub Wiring:**
+- `_run_enrichment(files: list[Path], config: DocvetConfig)` — existing stub, enrichment replaces the body
+- CLI dispatch already handles discovery mode resolution and config loading
+
+### Prerequisite PRs
+
+Two PRs must ship before the main enrichment PR:
+
+1. **Config update PR:** Add `require_attributes: bool = True` to `EnrichmentConfig`, update `_VALID_ENRICHMENT_KEYS`, update `_parse_enrichment` validation, update affected tests
+2. **`checks` package PR:** Create `src/docvet/checks/__init__.py` with `Finding` frozen dataclass (6 fields: `file`, `line`, `symbol`, `rule`, `message`, `category`). Shared type contract for all check modules
+
+### Technology Stack Reference
+
+Build system, quality toolchain, testing infrastructure, and code style rules are documented in `_bmad-output/project-context.md` (73 rules) and `CLAUDE.md`. Key constraints relevant to enrichment:
+
+- No new runtime dependencies — stdlib `ast`, `re`, and existing `ast_utils` only
+- Google-style docstrings assumed throughout
+- `from __future__ import annotations` in every file
+- Checks are isolated — no cross-imports between check modules
+- Tests use source string fixtures with `parse_source` factory, never mock AST nodes
+
+## Core Architectural Decisions
+
+### Decision Priority Analysis
+
+**Critical Decisions (Block Implementation):**
+1. Internal module organization (private function per rule)
+2. AST node-to-Symbol mapping (line-based index)
+3. Section header regex strategy (lenient with compiled pattern)
+
+**Important Decisions (Shape Architecture):**
+4. Finding message format (convention-based, two patterns)
+5. Error handling strategy (defensive by design, no try/except)
+
+**Deferred Decisions (Post-MVP):**
+- Production hardening (orchestrator-level catch-all for unforeseen edge cases)
+- Message truncation thresholds for long evidence lists
+- Inline suppression mechanism (`# docvet: ignore[rule]`)
+
+### Decision 1: Internal Module Organization
+
+**Decision:** Private function per rule (Option A with uniform signature)
+
+Each of the 10 rules is implemented as a `_check_*` private function with a uniform signature:
+
+```python
+def _check_missing_raises(
+    symbol: Symbol,
+    sections: set[str],
+    node_index: dict[int, ast.AST],
+    config: EnrichmentConfig,
+    file_path: str,
+) -> Finding | None:
+```
+
+**Config gating lives in the orchestrator**, not inside `_check_*` functions. The orchestrator checks the config toggle and skips calling a `_check_*` entirely when its toggle is off. This keeps detection logic pure — zero config awareness inside rule functions.
+
+**Config gating clarification — boolean vs. list toggles:**
+- **Boolean toggles** (9 rules): Orchestrator checks `config.require_raises`, etc. If `False`, skip the call entirely.
+- **List toggle** (`require_examples`): Orchestrator checks `if not config.require_examples` (empty list is falsy). If non-empty, the `_check_missing_examples` function reads `config.require_examples` internally to determine which `symbol.kind` values trigger the rule. This is the only `_check_*` function that inspects config — justified because the gating is symbol-type-specific, not a simple on/off.
+
+**Rationale:** Simplest structure satisfying NFR10 (rule independence) and NFR11 (3-file change ceiling). No registry, no abstraction — 10 functions, each self-contained and independently testable.
+
+### Decision 2: AST Node-to-Symbol Mapping
+
+**Decision:** Line-based index (Option C)
+
+`_build_node_index(tree: ast.Module) -> dict[int, ast.AST]` performs one `ast.walk()` pass, collecting `FunctionDef | AsyncFunctionDef | ClassDef` nodes, indexed by `lineno`. Called once at the top of `check_enrichment`.
+
+- Line numbers are unique per node — no name collision risk
+- Nested functions handled correctly (each gets its own `lineno` entry)
+- `node_index` replaces `tree` in the uniform `_check_*` signature — no rule needs to walk the raw tree
+- Module symbols (line 1, no corresponding node) handled by `node_index.get()` returning `None`
+
+**Note on `missing-attributes` branch 4 (plain class):** This branch requires a nested AST walk within the `ClassDef` node — `ClassDef.body` → find `FunctionDef` named `__init__` → walk its body for `ast.Assign` / `ast.AnnAssign` with `self.*` targets. The `ClassDef` is retrieved from `node_index`; the nested walk is internal to `_check_missing_attributes`. Implementing agents should expect this additional complexity in the highest-tier rule.
+
+**Rationale:** O(1) lookup per rule per symbol vs. O(n) per walk. One pass over the tree serves all 4 medium-tier rules that need body inspection.
+
+### Decision 3: Section Header Regex
+
+**Decision:** Lenient matching with single compiled regex
+
+```python
+_SECTION_HEADERS = frozenset({
+    "Args", "Returns", "Raises", "Yields", "Receives",
+    "Warns", "Other Parameters", "Attributes", "Examples", "See Also",
+})
+
+_SECTION_PATTERN = re.compile(
+    r"^\s*(Args|Returns|Raises|Yields|Receives|Warns|Other Parameters|Attributes|Examples|See Also):\s*$",
+    re.MULTILINE,
+)
+```
+
+`_parse_sections(docstring: str) -> set[str]` uses `re.findall()` with the capturing group, returning matched header names as a set.
+
+- `\s*` (zero or more) leading whitespace — handles module-level docstrings with no indent
+- False negatives (safe direction) preferred over false positives (NFR5)
+- Code block edge case is theoretical and produces false negatives, not false positives
+- `_SECTION_HEADERS` constant is testable and extensible (one-line future additions)
+
+**Rationale:** Recognizes well-intentioned docstrings with varied indentation. A developer who wrote a complete `Raises:` section at any indent level has documented their raises — the tool should not produce a false positive.
+
+### Decision 4: Finding Message Format
+
+**Decision:** Convention-based, two patterns (not code-enforced)
+
+Each `_check_*` owns its message f-string, following documented conventions:
+
+**Missing-section rules** (7 rules):
+`{SymbolKind} '{name}' {evidence} but has no {Section}: section`
+
+Examples:
+- `Function 'parse_config' raises ValueError, FileNotFoundError but has no Raises: section`
+- `Dataclass 'ValidationResult' has 6 fields but has no Attributes: section`
+
+**Format rules** (3 rules):
+`{Section}: section in {symbolKind} '{name}' {format issue}`
+
+Examples:
+- `Attributes: section in class 'Foo' lacks typed format (name (type): description)`
+- `Examples: section in function 'bar' uses doctest format (>>>) instead of fenced code blocks`
+
+**Rationale:** Evidence is rule-specific (exception names, field count, etc.) — a shared template would be more complex than individual f-strings. Convention ensures consistency; per-rule ownership enables specificity. Truncation of long evidence lists is a per-rule implementation detail.
+
+### Decision 5: Error Handling Strategy
+
+**Decision:** Defensive by design, no try/except in MVP
+
+Three defensive gates eliminate crash paths without exception handling:
+
+1. **`_parse_sections()`** — regex on string input, always returns `set[str]`, empty set on no matches (never raises)
+2. **`node_index.get(symbol.line)`** — `_check_*` functions use `.get()`, return `None` early if node is missing
+3. **Orchestrator** — skips symbols with no docstring before calling any `_check_*`
+
+No try/except in `_check_*` functions. They are pure logic, trusted through comprehensive tests. Swallowing exceptions would mask real bugs during development.
+
+**Rationale:** Correctness through design, not exception catching. If a `_check_*` has a logic error, it should crash in tests so it gets fixed. Production hardening (orchestrator-level catch-all) deferred to post-MVP.
+
+### Decision Impact Analysis
+
+**Full Implementation Sequence (including prerequisites):**
+1. **Prereq PR 1:** `require_attributes` config toggle in `config.py`
+2. **Prereq PR 2:** `checks/__init__.py` with `Finding` frozen dataclass
+3. `_SECTION_HEADERS` constant and `_SECTION_PATTERN` compiled regex (Decision 3)
+4. `_parse_sections()` function (Decision 3)
+5. `_build_node_index()` function (Decision 2)
+6. 10 `_check_*` functions following uniform signature (Decisions 1, 4, 5)
+7. `check_enrichment()` orchestrator with config gating (Decision 1)
+
+**Cross-Decision Dependencies:**
+- Decision 1 (module org) defines the signature that Decisions 2, 4, 5 fill in
+- Decision 2 (node index) replaces `tree` in the signature from Decision 1
+- Decision 3 (section parsing) produces the `sections` parameter consumed by all `_check_*` functions
+- Decision 5 (error handling) shapes how Decisions 2 and 3 handle edge cases
+- Prereq PR 2 (`Finding` dataclass) must exist before any `_check_*` function can be written
+
+## Implementation Patterns & Consistency Rules
+
+### Conflict Points Identified
+
+7 areas where AI agents implementing the enrichment module could make inconsistent choices.
+
+### Naming Patterns
+
+**Private function naming:**
+- Pattern: `_check_{rule_id_with_underscores}` — directly derived from the kebab-case rule identifier
+- `missing-raises` → `_check_missing_raises`
+- `missing-attributes` → `_check_missing_attributes`
+- `prefer-fenced-code-blocks` → `_check_prefer_fenced_code_blocks`
+- **Anti-pattern:** `_check_raises`, `_raises_check`, `_detect_missing_raises` — any deviation from the rule ID
+
+**Helper function naming:**
+- Pattern: `_build_*` for index/data structure construction, `_parse_*` for text parsing, `_has_*` for boolean checks, `_is_*` for type/state checks
+- Examples: `_build_node_index`, `_parse_sections`, `_has_self_assignments`, `_is_dataclass`
+- **Anti-pattern:** Generic names like `_helper`, `_process`, `_do_check`
+
+**Constants:**
+- Pattern: `ALL_CAPS_WITH_UNDER` at module level (per project context rules)
+- `_SECTION_HEADERS`, `_SECTION_PATTERN`
+- Private constants prefixed with `_` (not exported)
+
+### Structure Patterns
+
+**File organization within `enrichment.py`:**
+1. Module docstring
+2. `from __future__ import annotations`
+3. Stdlib imports (`ast`, `re`)
+4. Local imports (`from docvet.ast_utils import ...`, `from docvet.checks import Finding`, `from docvet.config import EnrichmentConfig`)
+5. Module-level constants (`_SECTION_HEADERS`, `_SECTION_PATTERN`)
+6. Shared helper functions (`_parse_sections`, `_build_node_index`)
+7. Rule-specific helper functions (`_has_self_assignments`, `_is_dataclass`, etc.)
+8. `_check_*` functions (ordered by rule taxonomy table — same order as PRD)
+9. `check_enrichment` public orchestrator (last function in file)
+
+**Taxonomy-table order** is the canonical ordering used for both function definitions and dispatch:
+`missing-raises`, `missing-yields`, `missing-receives`, `missing-warns`, `missing-other-parameters`, `missing-attributes`, `missing-typed-attributes`, `missing-examples`, `missing-cross-references`, `prefer-fenced-code-blocks`
+
+**`_check_missing_attributes` internal organization:**
+- Two distinct code paths based on symbol type:
+  - **Class symbols** (`symbol.kind == "class"`): Branches 1-4 use `node_index.get(symbol.line)` to retrieve the `ClassDef` node, then inspect decorators/bases/body
+  - **Module symbols** (`symbol.kind == "module"`): Branch 5 checks `file_path.endswith("__init__.py")`, no node needed
+- 5 branches ordered per architectural constraint, each as a helper function: `_is_dataclass(node)`, `_is_namedtuple(node)`, `_is_typeddict(node)`, `_has_self_assignments(node)`, `_is_init_module(file_path)`
+- First match wins, no fallthrough
+
+**Test organization:**
+- `tests/unit/checks/test_enrichment.py` — organized by rule in taxonomy-table order
+- Test naming: `test_{rule_id}_when_{condition}_returns_{expected}` (per project context)
+- Example: `test_missing_raises_when_function_raises_without_section_returns_finding`
+
+**Dual testing strategy:**
+- **Simple rules (9 of 10):** Test through `check_enrichment` with targeted config (disable all rules except the one under test). Tests config gating AND detection logic in one shot.
+- **`missing-attributes`:** Test `_check_missing_attributes` directly + test each branch helper (`_is_dataclass`, `_is_namedtuple`, etc.) individually + integration tests through `check_enrichment` for dispatch order verification.
+
+### AST Inspection Patterns
+
+**Node type checking:**
+- Always use `isinstance()` — `isinstance(node, ast.Raise)`, never `type(node) is ast.Raise`
+- Check both sync and async variants: `isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))`
+
+**AST traversal rules:**
+- Use `ast.walk(node)` for **deep subtree traversal** (e.g., finding all `raise` statements in a function body)
+- Use direct `.body` iteration for **immediate children** (e.g., finding `__init__` in `ClassDef.body`)
+- **Never write hand-rolled recursive tree walkers** — `ast.walk()` handles all deep traversal needs
+
+**Decorator inspection (for dataclass detection):**
+- Check both `@dataclass` and `@dataclasses.dataclass`
+- Handle `ast.Name` (simple decorator) and `ast.Attribute` (qualified decorator)
+- Handle `ast.Call` (decorator with arguments: `@dataclass(frozen=True)`)
+
+**Base class inspection (for NamedTuple/TypedDict):**
+- Check `node.bases` for `ast.Name` with `id` in `{"NamedTuple", "TypedDict"}`
+- Check `ast.Attribute` for qualified form: `typing.NamedTuple`, `typing.TypedDict`
+
+**`self.*` assignment detection (for plain class attributes):**
+- Walk `__init__` body for `ast.Assign` where target is `ast.Attribute` with `value.id == "self"`
+- Also check `ast.AnnAssign` for annotated assignments: `self.x: int = 0`
+
+### Finding Construction Pattern
+
+**All `_check_*` functions construct findings identically:**
+
+```python
+return Finding(
+    file=file_path,
+    line=symbol.line,
+    symbol=symbol.name,
+    rule="missing-raises",  # literal string, matches rule taxonomy
+    message=f"Function '{symbol.name}' raises ValueError but has no Raises: section",
+    category="required",  # literal string from rule taxonomy
+)
+```
+
+- `file` is always `file_path` (passed through, not computed)
+- `line` is always `symbol.line` (not the AST node line)
+- `symbol` is always `symbol.name`
+- `rule` is always a string literal matching the rule taxonomy
+- `category` is always a string literal (`"required"` or `"recommended"`) matching the rule taxonomy
+- **Anti-pattern:** Computing line from AST node, using dynamic rule/category strings
+
+### Orchestrator Pattern
+
+**`check_enrichment` follows this exact sequence:**
+
+```python
+def check_enrichment(
+    source: str,
+    tree: ast.Module,
+    config: EnrichmentConfig,
+    file_path: str,
+) -> list[Finding]:
+    symbols = get_documented_symbols(source, tree)
+    node_index = _build_node_index(tree)
+    findings: list[Finding] = []
+
+    for symbol in symbols:
+        if not symbol.docstring:
+            continue
+        sections = _parse_sections(symbol.docstring)
+
+        # Config-gated rule dispatch (taxonomy-table order)
+        if config.require_raises:
+            if f := _check_missing_raises(symbol, sections, node_index, config, file_path):
+                findings.append(f)
+        # ... repeat for each rule in taxonomy-table order ...
+
+    return findings
+```
+
+- Symbols without docstrings skipped first (FR20)
+- `_parse_sections` called once per symbol
+- Config toggle checked before each `_check_*` call
+- Walrus operator (`if f :=`) for concise finding collection
+- Rules dispatched in taxonomy-table order
+
+### Enforcement Guidelines
+
+**All AI agents implementing enrichment MUST:**
+- Follow the file organization order (constants → helpers → rules → orchestrator)
+- Use taxonomy-table order for both function definitions and dispatch
+- Use the uniform `_check_*` signature — no per-rule signature variations
+- Construct `Finding` objects with literal `rule` and `category` strings
+- Use `isinstance()` for AST node type checking
+- Use `ast.walk()` for deep subtree traversal; direct `.body` iteration for immediate children
+- Place config gating in the orchestrator, not in `_check_*` functions
+- Name private functions derivable from the rule ID
+
+**Pattern verification:** ruff + ty enforce naming, import order, and type consistency. Test coverage (>=90% on `enrichment.py`) enforces behavioral correctness.
+
+## Project Structure & Boundaries
+
+### Complete Project Directory Structure
+
+Existing files shown as-is. **New files for enrichment** marked with `← NEW`.
+
+```
+src/docvet/
+├── __init__.py
+├── cli.py                    # _run_enrichment stub → wired to check_enrichment
+├── config.py                 # EnrichmentConfig (add require_attributes) ← MODIFIED
+├── discovery.py
+├── ast_utils.py              # get_documented_symbols (consumed by enrichment)
+├── reporting.py
+└── checks/
+    ├── __init__.py            ← NEW (Finding dataclass)
+    └── enrichment.py          ← NEW (check_enrichment + 10 _check_* functions)
+
+tests/
+├── conftest.py               # parse_source factory (existing)
+├── unit/
+│   ├── test_config.py         # Tests for require_attributes toggle ← MODIFIED
+│   └── checks/
+│       ├── __init__.py
+│       └── test_enrichment.py ← NEW (all enrichment rule tests)
+├── integration/
+│   └── conftest.py
+└── fixtures/
+    ├── complete_module.py     # Existing — zero findings expected
+    ├── missing_raises.py      # Existing — missing-raises finding expected
+    └── missing_yields.py      # Existing — missing-yields finding expected
+```
+
+### Architectural Boundaries
+
+**Public API boundary:**
+- `check_enrichment(source, tree, config, file_path) -> list[Finding]` — the only public function in `enrichment.py`
+- `Finding` — the only export from `checks/__init__.py`
+- Everything else in `enrichment.py` is private (`_` prefixed)
+
+**Module dependency boundary:**
+```
+cli.py
+  → imports check_enrichment from docvet.checks.enrichment
+  → imports Finding from docvet.checks
+  → imports EnrichmentConfig from docvet.config
+  → imports discover_files from docvet.discovery
+
+checks/enrichment.py
+  → imports Finding from docvet.checks
+  → imports Symbol, get_documented_symbols from docvet.ast_utils
+  → imports EnrichmentConfig from docvet.config
+  → NEVER imports from docvet.cli, docvet.discovery, or other checks/*
+```
+
+**Data boundary:**
+- No I/O inside enrichment — pure function, no file reads, no subprocess calls
+- `source` and `tree` provided by caller (CLI reads files and calls `ast.parse`)
+- `file_path` is a string for context only — enrichment never opens it
+
+### Requirements to Structure Mapping
+
+**FR Category → File Mapping:**
+
+| FR Category | Primary File | Supporting Files |
+|------------|-------------|-----------------|
+| Section Detection (FR1-FR15) | `checks/enrichment.py` (`_check_*` functions) | — |
+| Finding Production (FR16-FR22) | `checks/__init__.py` (`Finding` dataclass) | `checks/enrichment.py` (construction) |
+| Rule Management (FR23-FR25) | `checks/enrichment.py` (rule ID literals in `_check_*`) | — |
+| Configuration (FR26-FR31) | `config.py` (`EnrichmentConfig`) | `checks/enrichment.py` (orchestrator gating) |
+| Symbol Analysis (FR32-FR38) | `ast_utils.py` (`get_documented_symbols`) | `checks/enrichment.py` (`_build_node_index`, `_parse_sections`) |
+| Integration (FR39-FR42) | `cli.py` (`_run_enrichment`) | `checks/enrichment.py` (`check_enrichment`) |
+
+**FR15 clarification:** `Args` and `Returns` are included in `_SECTION_PATTERN` for parsing context only — they allow `_parse_sections` to return a complete picture of which sections exist. No `_check_missing_args` or `_check_missing_returns` function exists because layers 1-2 (presence and style) are ruff/interrogate territory, not docvet's.
+
+**Rule → Internal Function Mapping:**
+
+| Rule | `_check_*` Function | Node Index Usage | Helpers Used |
+|------|---------------------|-----------------|-------------|
+| `missing-raises` | `_check_missing_raises` | Body walk (find `ast.Raise`) | `_parse_sections` |
+| `missing-yields` | `_check_missing_yields` | Body walk (find `ast.Yield`) | `_parse_sections` |
+| `missing-receives` | `_check_missing_receives` | Body walk (find `ast.Yield` as assignment target) | `_parse_sections` |
+| `missing-warns` | `_check_missing_warns` | Body walk (find `warnings.warn()` call) | `_parse_sections` |
+| `missing-other-parameters` | `_check_missing_other_parameters` | Signature only (`node.args.kwarg`) | `_parse_sections` |
+| `missing-attributes` | `_check_missing_attributes` | Class node (decorators/bases/body) | `_is_dataclass`, `_is_namedtuple`, `_is_typeddict`, `_has_self_assignments`, `_is_init_module` |
+| `missing-typed-attributes` | `_check_missing_typed_attributes` | Not used (docstring-only) | `_parse_sections` |
+| `missing-examples` | `_check_missing_examples` | Not used (docstring-only + config list) | `_parse_sections`, `config.require_examples` |
+| `missing-cross-references` | `_check_missing_cross_references` | Not used (docstring-only + `file_path`) | `_parse_sections` |
+| `prefer-fenced-code-blocks` | `_check_prefer_fenced_code_blocks` | Not used (docstring-only) | `_parse_sections` |
+
+### Data Flow
+
+```
+CLI (_run_enrichment)
+  │
+  │  reads file → source: str
+  │  try: ast.parse(source) → tree: ast.Module
+  │  except SyntaxError: skip file with warning, do NOT call check_enrichment
+  │  loads config → config.enrichment: EnrichmentConfig
+  │
+  ▼
+check_enrichment(source, tree, config, file_path)
+  │
+  │  get_documented_symbols(source, tree) → symbols: list[Symbol]
+  │  _build_node_index(tree) → node_index: dict[int, ast.AST]
+  │
+  ▼
+  for each symbol (skip if no docstring):
+  │
+  │  _parse_sections(symbol.docstring) → sections: set[str]
+  │
+  │  for each enabled rule (config gating, taxonomy-table order):
+  │    _check_*(symbol, sections, node_index, config, file_path)
+  │      → Finding | None
+  │
+  ▼
+list[Finding] returned to CLI
+```
+
+### Integration Points
+
+**Enrichment ↔ CLI integration:**
+- CLI calls `check_enrichment` once per file (file-at-a-time processing)
+- **CLI must wrap `ast.parse()` in try/except SyntaxError** — files that fail to parse are skipped with a warning, never passed to `check_enrichment`
+- CLI aggregates `list[Finding]` across files
+- CLI applies `fail-on` / `warn-on` logic to determine exit code
+- CLI formats findings as `file:line: rule message` for terminal output
+
+**Enrichment ↔ Config integration:**
+- `EnrichmentConfig` loaded once by CLI, passed to every `check_enrichment` call
+- Config is immutable within a run — no per-file config variation
+- Missing `[tool.docvet.enrichment]` section → all defaults (all rules enabled)
+
+**Enrichment ↔ AST Utils integration:**
+- `get_documented_symbols` is the only `ast_utils` function called
+- `Symbol` dataclass is the only type consumed
+- No enrichment-specific changes to `ast_utils.py`
+
+## Architecture Validation Results
+
+### Coherence Validation ✅
+
+**Decision Compatibility:**
+All 5 decisions interlock without contradiction:
+- Decision 1 (uniform signature) defines the shape → Decisions 2 and 3 fill in the `node_index` and `sections` parameters
+- Decision 2 (`node_index.get()`) and Decision 3 (`_parse_sections` returning empty set) both satisfy Decision 5 (defensive design) without try/except
+- Decision 4 (per-rule message ownership) aligns with Decision 1 (each `_check_*` self-contained)
+- Config gating clarification (boolean vs list toggle) is consistent between Decision 1 and the orchestrator pattern
+
+**Pattern Consistency:**
+- Naming conventions: `_check_*` from rule ID, `_build_*`/`_parse_*`/`_has_*`/`_is_*` for helpers — no conflicts
+- Taxonomy-table order enforced for both function definitions and dispatch — single canonical ordering
+- Finding construction uses literal strings for `rule` and `category` everywhere — no dynamic strings
+- File organization order (constants → helpers → rules → orchestrator) supports top-down readability
+
+**Structure Alignment:**
+- 2 new files + 2 modified supports all 5 decisions without structural compromise
+- Public API boundary (`check_enrichment` + `Finding`) cleanly separates enrichment internals from CLI
+- Module dependency graph is acyclic: `cli → enrichment → {checks.Finding, ast_utils, config}` — no circular deps
+- Data boundary (no I/O in enrichment) is structurally enforced by the function signature
+
+### Requirements Coverage Validation ✅
+
+**Functional Requirements (42/42 covered):**
+
+| FR Category | FRs | Architecture Support |
+|------------|-----|---------------------|
+| Section Detection | FR1-FR15 | Each maps to a `_check_*` function + `_parse_sections` + `_SECTION_PATTERN` |
+| Finding Production | FR16-FR22 | `Finding` dataclass (FR16-17, FR22), orchestrator patterns (FR18-FR21) |
+| Rule Management | FR23-FR25 | Literal rule IDs in `_check_*`, taxonomy table, 14→10 mapping |
+| Configuration | FR26-FR31 | Orchestrator config gating, `_check_missing_examples` list access, `_SECTION_HEADERS` constant |
+| Symbol Analysis | FR32-FR38 | `_build_node_index` + body walk (FR32-33), `file_path` context (FR34), `_parse_sections` (FR35-36), docstring skip (FR37), defensive design (FR38) |
+| Integration | FR39-FR42 | `check_enrichment` signature (FR39-40), `checks/__init__.py` export (FR41), CLI stub wiring (FR42) |
+
+**Non-Functional Requirements (19/19 covered):**
+
+| NFR Category | NFRs | Architecture Support |
+|-------------|------|---------------------|
+| Performance | NFR1-4 | Single-pass node index, compiled regex, stateless per-file processing, no cross-file state |
+| Correctness | NFR5-9 | Lenient regex (false negatives > false positives), pure function design, defensive gates, actionable message conventions |
+| Maintainability | NFR10-13 | Private function per rule, 3-file change ceiling via module structure, dual testing strategy, existing CI gates |
+| Compatibility | NFR14-16 | Stdlib-only approach, no platform-specific code, no new deps |
+| Integration | NFR17-19 | Frozen `Finding` dataclass, `_run_enrichment` stub, backward-compatible `require_attributes` default |
+
+### Implementation Readiness Validation ✅
+
+**Decision Completeness:**
+- All 5 decisions include rationale, code examples, and anti-patterns
+- Uniform `_check_*` signature specified with exact type annotations
+- Prerequisite PRs identified with specific scope (config toggle, `Finding` dataclass)
+- Implementation sequence numbered 1-7 with cross-decision dependencies mapped
+- Config gating exception (`require_examples` list) explicitly documented
+- Each `_check_*` function includes a test case where `node_index.get(symbol.line)` returns `None`, confirming the defensive early-return path (module-level symbols, decorator-only symbols, etc.)
+
+**Structure Completeness:**
+- File tree shows every new/modified file with markers
+- Import paths specified for all cross-module dependencies
+- FR→file mapping table covers all 42 FRs
+- Rule→function mapping table covers all 10 rules with node index usage and helpers
+
+**Pattern Completeness:**
+- AST inspection patterns cover all node types: `ast.Raise`, `ast.Yield`, `ast.Call`, `ast.Name`, `ast.Attribute`, decorator handling, base class inspection, `self.*` assignment detection
+- `missing-attributes` branch 4 nested walk explicitly called out as highest-complexity area
+- `missing-other-parameters` uses signature-only access (`node.args.kwarg`), distinct from body walk rules
+- Dual testing strategy differentiates simple rules (through orchestrator) from complex rules (direct + helper testing)
+- Body-walk rules (`missing-raises`, `missing-yields`, `missing-receives`, `missing-warns`) retrieve the function node via `node_index.get(symbol.line)` and traverse `node.body` with `ast.walk()`
+
+### Gap Analysis Results
+
+**Critical Gaps:** 0 — No missing decisions that block implementation.
+
+**Important Gaps:** 1
+
+1. **`missing-cross-references` detection criteria undefined.** The architecture maps FR12 to `_check_missing_cross_references` and notes it's docstring-only, but "cross-reference syntax" is never formally defined. The PRD validation report flagged FR12 as the weakest FR (S=3, M=3, A=3, R=3). This is a PRD-level gap inherited by the architecture — the tech spec will need to define what constitutes valid cross-reference syntax (likely `:func:`, `:class:`, `:mod:` role syntax or bare `module.symbol` references).
+
+**Scope Boundaries (not gaps):**
+
+1. **Decorator detection scope.** MVP supports `@dataclass` and `@dataclasses.dataclass` forms only — aliased imports (`from dataclasses import dataclass as dc`) are explicitly out of MVP scope.
+2. **`async` generator edge cases.** `async for`/`async with` patterns and their interaction with `missing-yields`/`missing-receives` are not explicitly addressed. The `ast.walk()` approach handles `ast.AsyncFunctionDef` but the specific `ast.Yield` vs `ast.YieldFrom` distinction within async generators could be clarified in the tech spec.
+
+### Architecture Completeness Checklist
+
+**✅ Requirements Analysis**
+
+- [x] Project context thoroughly analyzed (42 FRs, 19 NFRs, 5 journeys)
+- [x] Scale and complexity assessed (medium, CLI single-process)
+- [x] Technical constraints identified (no new deps, Google-style only, caller handles SyntaxError)
+- [x] Cross-cutting concerns mapped (config toggle respect, no-docstring skip, malformed resilience, deduplication)
+
+**✅ Architectural Decisions**
+
+- [x] 5 critical/important decisions documented with rationale and code examples
+- [x] Technology stack constrained to stdlib `ast` + `re` + existing `ast_utils`
+- [x] Integration patterns defined (CLI ↔ enrichment, enrichment ↔ config, enrichment ↔ ast_utils)
+- [x] Performance addressed (single-pass node index, compiled regex, stateless processing)
+
+**✅ Implementation Patterns**
+
+- [x] Naming conventions established (`_check_*`, `_build_*`, `_parse_*`, `_has_*`, `_is_*`)
+- [x] Structure patterns defined (file organization order, taxonomy-table ordering)
+- [x] AST inspection patterns specified (isinstance, ast.walk vs .body, decorator/base class handling)
+- [x] Process patterns documented (finding construction, orchestrator dispatch, config gating)
+
+**✅ Project Structure**
+
+- [x] Complete directory structure with NEW/MODIFIED markers
+- [x] Component boundaries established (public API, module dependencies, data boundary)
+- [x] Integration points mapped (CLI, config, ast_utils)
+- [x] Requirements-to-structure mapping complete (FR→file table, rule→function table)
+
+### Architecture Readiness Assessment
+
+**Overall Status:** READY FOR IMPLEMENTATION
+
+**Confidence Level:** High
+
+**Key Strengths:**
+- Complete FR and NFR coverage with no critical gaps
+- All decisions interlock coherently — no contradictions or incompatibilities
+- Code examples and anti-patterns provide clear implementation guidance for AI agents
+- Prerequisite PRs cleanly isolate dependencies from the main implementation
+- Defensive error handling eliminates crash paths by design rather than exception catching
+- Dual testing strategy appropriately scales test depth with rule complexity
+
+**Areas for Future Enhancement:**
+- Cross-reference syntax definition (deferred to tech spec — structural support is in place)
+- Decorator alias detection (explicit MVP scope boundary — can be added per NFR11's 3-file ceiling)
+- Message truncation thresholds for long evidence lists (explicitly deferred to post-MVP)
+
+### Implementation Handoff
+
+**AI Agent Guidelines:**
+- Follow all architectural decisions exactly as documented
+- Use implementation patterns consistently — taxonomy-table order, uniform signatures, literal strings
+- Respect project structure and boundaries — no cross-check imports, no I/O in enrichment
+- Refer to this document for all architectural questions before escalating
+
+**First Implementation Priority:**
+1. Prerequisite PR 1: `require_attributes` config toggle
+2. Prerequisite PR 2: `checks/__init__.py` with `Finding` dataclass
+3. Main enrichment PR: `check_enrichment` + 10 `_check_*` functions + tests

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -1,0 +1,682 @@
+---
+stepsCompleted:
+  - 'step-01-validate-prerequisites'
+  - 'step-02-design-epics'
+  - 'step-03-create-stories'
+  - 'step-04-final-validation'
+status: 'complete'
+inputDocuments:
+  - '_bmad-output/planning-artifacts/prd.md'
+  - '_bmad-output/planning-artifacts/architecture.md'
+  - '_bmad-output/planning-artifacts/prd-validation-report.md'
+---
+
+# docvet - Epic Breakdown
+
+## Overview
+
+This document provides the complete epic and story breakdown for docvet, decomposing the requirements from the PRD and Architecture into implementable stories for the **enrichment check module** (Layer 3: completeness).
+
+## Requirements Inventory
+
+### Functional Requirements
+
+**Section Detection (FR1-FR15):**
+
+- FR1: The system can detect functions and methods that contain `raise` statements but lack a `Raises:` section in their docstring
+- FR2: The system can detect generator functions that contain `yield` expressions but lack a `Yields:` section in their docstring
+- FR3: The system can detect generators that use the `value = yield` send pattern but lack a `Receives:` section in their docstring
+- FR4: The system can detect functions that call `warnings.warn()` but lack a `Warns:` section in their docstring
+- FR5: The system can detect functions with `**kwargs` parameters but lack an `Other Parameters:` section in their docstring
+- FR6: The system can detect classes with `__init__` self-assignments that lack an `Attributes:` section in their docstring
+- FR7: The system can detect dataclasses, NamedTuples, and TypedDicts with fields that lack an `Attributes:` section in their docstring
+- FR8: The system can detect `__init__.py` modules that lack an `Attributes:` section documenting their exports
+- FR9: The system can detect public symbols (configurable by type) that lack an `Examples:` section in their docstring
+- FR10: The system can detect `__init__.py` modules that lack an `Examples:` section in their docstring
+- FR11: The system can detect `Attributes:` sections that lack typed format (`name (type): description`)
+- FR12: The system can detect `See Also:` sections that lack cross-reference syntax
+- FR13: The system can detect `__init__.py` modules that lack a `See Also:` section in their docstring
+- FR14: The system can detect `Examples:` sections that use `>>>` doctest format instead of fenced code blocks
+- FR15: The system can recognize `Args:` and `Returns:` section headers for docstring parsing context without checking for their absence
+
+**Finding Production (FR16-FR22):**
+
+- FR16: The system can produce a structured finding for each detected issue, carrying file path, line number, symbol name, rule identifier, human-readable message, and category
+- FR17: The system can categorize each finding as `required` (misleading omission) or `recommended` (improvement opportunity) based on the rule definition
+- FR18: The system can produce at most one finding per symbol per rule, even when multiple detection branches match the same symbol
+- FR19: The system can produce zero findings when analyzing well-documented code with complete docstrings
+- FR20: The system can produce zero findings for symbols that have no docstring
+- FR21: The system can produce findings only for missing sections, not for sections that exist but are incomplete
+- FR22: The system can provide Finding as an immutable (frozen) dataclass that cannot be modified after creation
+
+**Rule Management (FR23-FR25):**
+
+- FR23: The system can identify each finding with a stable, human-readable kebab-case rule identifier (e.g., `missing-raises`, `missing-yields`)
+- FR24: A developer can reference rule identifiers in configuration, output filtering, and issue tracking
+- FR25: The system can map 14 detection scenarios to 10 distinct rule identifiers, applying the same rule ID across related detection contexts
+
+**Configuration (FR26-FR31):**
+
+- FR26: A developer can enable or disable each of the 10 rules independently via boolean toggles in `[tool.docvet.enrichment]`
+- FR27: A developer can configure which symbol types trigger the `missing-examples` rule via a list of type names (class, protocol, dataclass, enum)
+- FR28: The system can validate `require-examples` entries against known symbol types, rejecting unrecognized entries at config load time
+- FR29: A developer can disable all enrichment findings by setting `require-examples = []` and all boolean toggles to `false`
+- FR30: The system can apply defaults (all rules enabled, `require-examples = ["class", "protocol", "dataclass", "enum"]`) when no enrichment configuration is provided
+- FR31: The system can recognize 8 Google-style section headers (`Raises:`, `Yields:`, `Receives:`, `Warns:`, `Other Parameters:`, `Attributes:`, `Examples:`, `See Also:`) for missing section detection
+
+**Symbol Analysis (FR32-FR38):**
+
+- FR32: The system can analyze function and method symbols for raise statements, yield expressions, send patterns, warnings calls, and kwargs parameters
+- FR33: The system can analyze class symbols to determine construct type (plain class with `__init__`, dataclass, NamedTuple, TypedDict)
+- FR34: The system can analyze module symbols to determine if the source file is an `__init__.py`
+- FR35: The system can extract and parse raw docstring text from symbols to identify which sections are present
+- FR36: The system can analyze any symbol with a non-empty docstring, regardless of docstring length or section count
+- FR37: The system can distinguish between symbols that have a docstring (analyze for completeness) and symbols with no docstring (skip -- presence checking is interrogate's job)
+- FR38: The system can process docstrings with broken indentation, missing section-header colons, or non-standard header names without raising exceptions, producing zero findings for symbols whose docstrings cannot be reliably parsed
+
+**Integration (FR39-FR42):**
+
+- FR39: The system can accept source code, a parsed AST, configuration, and file path as inputs and return a list of findings as output
+- FR40: The system can operate as a pure function with no I/O, no side effects, and deterministic output
+- FR41: The system can provide `Finding` as a shared type importable by all check modules without cross-check dependencies
+- FR42: A developer can run the enrichment check standalone via `docvet enrichment` or as part of all checks via `docvet check`
+
+### NonFunctional Requirements
+
+**Performance (NFR1-NFR4):**
+
+- NFR1: The enrichment check can analyze a single file (<=1000 lines) in under 50ms (aspirational benchmark, not CI-enforced)
+- NFR2: The enrichment check can process a 200-file codebase via `docvet enrichment --all` in under 5 seconds on commodity hardware (aspirational)
+- NFR3: The enrichment check adds no measurable overhead beyond AST parsing
+- NFR4: Memory usage scales linearly with file count, not quadratically (each file processed independently with no cross-file state)
+
+**Correctness (NFR5-NFR9):**
+
+- NFR5: The enrichment check produces zero false positives on well-documented code with complete docstrings (deterministic, reproducible)
+- NFR6: The enrichment check produces identical output for identical input regardless of execution environment, time, or ordering
+- NFR7: Malformed docstrings (broken indentation, missing colons, non-standard headers) result in zero findings for that symbol, never a crash or traceback
+- NFR8: The enrichment check never modifies input data (source, tree, and config remain unchanged after execution)
+- NFR9: Finding messages are actionable (each message names the specific symbol, the specific issue, and what section is missing)
+
+**Maintainability (NFR10-NFR13):**
+
+- NFR10: Each of the 10 rules can be understood, modified, and tested independently without knowledge of other rules
+- NFR11: Adding a new detection rule requires changes to at most 3 files: the rule implementation, its config toggle, and its tests
+- NFR12: Test coverage on `checks/enrichment.py` targets >=90% (aspirational), with project-wide coverage maintaining the >=85% CI gate
+- NFR13: All quality gates pass: ruff check, ruff format, ty check, pytest, interrogate (95% docstring coverage)
+
+**Compatibility (NFR14-NFR16):**
+
+- NFR14: The enrichment check works on Python 3.12 and 3.13 (CI tests both versions)
+- NFR15: The enrichment check works on Linux, macOS, and Windows without platform-specific code paths
+- NFR16: No new runtime dependencies (stdlib `ast`, `re`, and existing `ast_utils` only)
+
+**Integration (NFR17-NFR19):**
+
+- NFR17: `Finding`'s 6-field shape (`file`, `line`, `symbol`, `rule`, `message`, `category`) is stable for v1
+- NFR18: The enrichment check integrates with the existing CLI dispatch pattern (`_run_enrichment` stub) without requiring changes to CLI argument parsing or global option handling
+- NFR19: Config additions (`require-attributes` toggle) are backward-compatible (existing `pyproject.toml` files without this key continue to work with the default value)
+
+### Additional Requirements
+
+**From Architecture:**
+
+- No starter template needed -- brownfield project with scaffolding already implemented
+- Prerequisite PR 1: Add `require_attributes: bool = True` to `EnrichmentConfig`, update `_VALID_ENRICHMENT_KEYS`, update `_parse_enrichment` validation, update affected tests
+- Prerequisite PR 2: Create `src/docvet/checks/__init__.py` with `Finding` frozen dataclass (6 fields: `file`, `line`, `symbol`, `rule`, `message`, `category`)
+- Implementation sequence: config toggle -> Finding dataclass -> section parsing constants/functions -> node index builder -> 10 `_check_*` functions -> `check_enrichment` orchestrator
+- `missing-attributes` dispatch order is an architectural constraint: dataclass -> NamedTuple -> TypedDict -> plain class -> `__init__.py` module (first-match-wins, no fallthrough)
+- Config gating lives in the orchestrator, not inside `_check_*` functions
+- Defensive error handling: no try/except in MVP; correctness through design (regex returns empty set, `.get()` returns None)
+- Dual testing strategy: simple rules tested through `check_enrichment` orchestrator; `missing-attributes` tested directly + per-helper + integration
+- Private function per rule with uniform signature: `_check_*(symbol, sections, node_index, config, file_path) -> Finding | None`
+- Single compiled regex for section header matching (`_SECTION_PATTERN`)
+- Line-based node index (`_build_node_index`) for O(1) AST node lookup per symbol
+- Finding construction uses literal strings for `rule` and `category` (no dynamic strings)
+- Taxonomy-table order for both function definitions and dispatch
+
+**From Validation Report:**
+
+- FR12 ("cross-reference syntax") is the weakest FR -- never formally defined; tech spec must define what constitutes valid cross-reference syntax
+- FR8 ambiguity: "exports" in `__init__.py` context needs clarification (is it `__all__`, public names, or both?)
+- FR11 needs explicit pattern: `name (type): description` as expected match vs `name: description` as violation
+- 4 rules lack user journey demonstration: `missing-receives`, `missing-other-parameters`, `missing-cross-references`, `prefer-fenced-code-blocks`
+- Decorator alias detection (e.g., `from dataclasses import dataclass as dc`) is explicitly out of MVP scope
+- `async` generator edge cases (`async for`/`async with` interaction with `missing-yields`/`missing-receives`) not explicitly addressed
+
+### FR Coverage Map
+
+| FR | Epic | Brief Description |
+|----|------|-------------------|
+| FR1 | Epic 1 | Detect missing Raises section |
+| FR2 | Epic 1 | Detect missing Yields section |
+| FR3 | Epic 1 | Detect missing Receives section |
+| FR4 | Epic 1 | Detect missing Warns section |
+| FR5 | Epic 1 | Detect missing Other Parameters section |
+| FR6 | Epic 2 | Detect missing Attributes on plain classes |
+| FR7 | Epic 2 | Detect missing Attributes on dataclasses/NamedTuples/TypedDicts |
+| FR8 | Epic 2 | Detect missing Attributes on `__init__.py` modules |
+| FR9 | Epic 3 | Detect missing Examples on configurable symbol types |
+| FR10 | Epic 3 | Detect missing Examples on `__init__.py` modules |
+| FR11 | Epic 3 | Detect untyped Attributes format |
+| FR12 | Epic 3 | Detect missing cross-reference syntax in See Also |
+| FR13 | Epic 3 | Detect missing See Also on `__init__.py` modules |
+| FR14 | Epic 3 | Detect doctest format instead of fenced code blocks |
+| FR15 | Epic 1 | Recognize Args/Returns headers for parsing context |
+| FR16 | Epic 1 | Finding dataclass with 6 fields |
+| FR17 | Epic 1 | Finding category (required/recommended) |
+| FR18 | Epic 1 | One finding per symbol per rule deduplication |
+| FR19 | Epic 1 | Zero findings on clean code |
+| FR20 | Epic 1 | Zero findings for undocumented symbols |
+| FR21 | Epic 1 | Missing-only detection (not incomplete) |
+| FR22 | Epic 1 | Finding is frozen/immutable |
+| FR23 | Epic 1 | Kebab-case rule identifiers |
+| FR24 | Epic 1 | Rule IDs usable in config/filtering/tracking |
+| FR25 | Epic 1 | 14 scenarios -> 10 rule ID mapping |
+| FR26 | Epic 1 | Per-rule boolean config toggles |
+| FR27 | Epic 3 | `require-examples` list config |
+| FR28 | Epic 1 | Validate `require-examples` entries |
+| FR29 | Epic 1 | Disable all findings via config |
+| FR30 | Epic 1 | Sensible defaults when no config provided |
+| FR31 | Epic 1 | Recognize 8 Google-style section headers |
+| FR32 | Epic 1 | Analyze functions for raise/yield/warn/kwargs patterns |
+| FR33 | Epic 2 | Analyze class construct types |
+| FR34 | Epic 2 | Analyze module symbols for `__init__.py` |
+| FR35 | Epic 1 | Extract and parse docstring sections |
+| FR36 | Epic 1 | Analyze any symbol with non-empty docstring |
+| FR37 | Epic 1 | Distinguish documented vs undocumented symbols |
+| FR38 | Epic 1 | Handle malformed docstrings gracefully |
+| FR39 | Epic 1 | Pure function API: source, tree, config, file_path -> findings |
+| FR40 | Epic 1 | No I/O, no side effects, deterministic |
+| FR41 | Epic 1 | Finding as shared type for all check modules |
+| FR42 | Epic 1 | CLI wiring: `docvet enrichment` and `docvet check` |
+
+## Epic List
+
+### Epic 1: Function-Level Enrichment Detection
+
+A developer can run `docvet enrichment` and get findings for missing `Raises:`, `Yields:`, `Receives:`, `Warns:`, and `Other Parameters:` sections on functions and methods — end-to-end from CLI invocation to terminal output. Includes the shared `Finding` dataclass, config updates, section parser, node index, 5 function-level `_check_*` rules, `check_enrichment` orchestrator, and CLI wiring.
+
+**FRs covered:** FR1, FR2, FR3, FR4, FR5, FR15, FR16, FR17, FR18, FR19, FR20, FR21, FR22, FR23, FR24, FR25, FR26, FR28, FR29, FR30, FR31, FR32, FR35, FR36, FR37, FR38, FR39, FR40, FR41, FR42
+
+### Story 1.1: Add `require_attributes` Config Toggle
+
+As a developer,
+I want a `require-attributes` boolean toggle in `[tool.docvet.enrichment]`,
+So that teams can enable or disable Attributes checking for classes independently.
+
+**Acceptance Criteria:**
+
+**Given** an `EnrichmentConfig` with no explicit `require-attributes` setting
+**When** the config is loaded from `pyproject.toml`
+**Then** `require_attributes` defaults to `True`
+
+**Given** a `pyproject.toml` with `require-attributes = false` under `[tool.docvet.enrichment]`
+**When** the config is loaded
+**Then** `require_attributes` is `False`
+
+**Given** an existing `pyproject.toml` without a `require-attributes` key
+**When** the config is loaded
+**Then** all existing config fields retain their values and no error is raised (backward-compatible)
+
+**Given** the `_VALID_ENRICHMENT_KEYS` set in `config.py`
+**When** inspected
+**Then** it includes `"require-attributes"`
+
+**Given** the `_parse_enrichment` function
+**When** it receives an unknown key (e.g., `require-foo = true`)
+**Then** it rejects the key at config load time with a clear error message
+
+**FRs:** FR26, FR29, FR30, NFR19
+
+### Story 1.2: Create `Finding` Dataclass
+
+As a developer,
+I want a shared, immutable `Finding` dataclass in `checks/__init__.py`,
+So that all check modules produce findings with a consistent, stable structure.
+
+**Acceptance Criteria:**
+
+**Given** the `checks/__init__.py` module
+**When** imported
+**Then** it exports `Finding` as the only public name
+
+**Given** a `Finding` instance
+**When** constructed with `file`, `line`, `symbol`, `rule`, `message`, `category`
+**Then** all 6 fields are accessible and the instance is frozen (immutable)
+
+**Given** a `Finding` instance
+**When** any field assignment is attempted (e.g., `finding.rule = "new"`)
+**Then** a `FrozenInstanceError` is raised
+
+**Given** the `category` field
+**When** a `Finding` is constructed
+**Then** it accepts `"required"` or `"recommended"` as valid values
+
+**Given** the `rule` field
+**When** a `Finding` is constructed
+**Then** it accepts any string (kebab-case rule identifiers like `"missing-raises"`)
+
+**FRs:** FR16, FR17, FR22, FR23, FR41, NFR17
+
+### Story 1.3: Section Header Parser and Node Index
+
+As a developer,
+I want shared infrastructure for parsing docstring sections and indexing AST nodes,
+So that all enrichment rules can efficiently determine which sections exist and look up AST nodes.
+
+**Acceptance Criteria:**
+
+**Given** a docstring containing `Raises:`, `Yields:`, and `Args:` section headers
+**When** `_parse_sections(docstring)` is called
+**Then** it returns `{"Raises", "Yields", "Args"}`
+
+**Given** a docstring with varied indentation (e.g., module-level with no indent, method-level with 8-space indent)
+**When** `_parse_sections(docstring)` is called
+**Then** it correctly identifies section headers regardless of leading whitespace
+
+**Given** a docstring with no recognized section headers
+**When** `_parse_sections(docstring)` is called
+**Then** it returns an empty set (never raises an exception)
+
+**Given** a malformed docstring with broken indentation or missing colons
+**When** `_parse_sections(docstring)` is called
+**Then** it returns an empty set (graceful degradation, no crash)
+
+**Given** `_SECTION_HEADERS` constant
+**When** inspected
+**Then** it contains all 10 recognized headers: `Args`, `Returns`, `Raises`, `Yields`, `Receives`, `Warns`, `Other Parameters`, `Attributes`, `Examples`, `See Also`
+
+**Given** an `ast.Module` tree with functions, classes, and async functions
+**When** `_build_node_index(tree)` is called
+**Then** it returns a `dict[int, ast.AST]` mapping line numbers to `FunctionDef | AsyncFunctionDef | ClassDef` nodes
+
+**Given** a module-level symbol (line 1) with no corresponding AST node
+**When** `node_index.get(symbol.line)` is called
+**Then** it returns `None` (safe for rules to handle)
+
+**FRs:** FR15, FR31, FR35, FR36, FR38, NFR7
+
+### Story 1.4: Missing Raises Detection and Orchestrator
+
+As a developer,
+I want to detect functions that raise exceptions without documenting them in a `Raises:` section,
+So that I can ensure my docstrings accurately describe error behavior for callers.
+
+**Acceptance Criteria:**
+
+**Given** a function with `raise ValueError` and a docstring with no `Raises:` section
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-raises"`, `category="required"`, and a message naming the function and the exception
+
+**Given** a function with `raise ValueError` and a docstring containing a `Raises:` section
+**When** `check_enrichment` is called
+**Then** it returns zero findings for that function (missing-only, not incomplete)
+
+**Given** a function with no `raise` statements
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-raises` on that function
+
+**Given** a function with `raise` but no docstring at all
+**When** `check_enrichment` is called
+**Then** it returns zero findings (undocumented symbols are skipped)
+
+**Given** `config.require_raises = False`
+**When** `check_enrichment` is called on a function with `raise` and no `Raises:` section
+**Then** it returns zero findings for `missing-raises` (config toggle respected)
+
+**Given** a well-documented file (`tests/fixtures/complete_module.py`)
+**When** `check_enrichment` is called
+**Then** it returns an empty list (zero findings)
+
+**Given** `tests/fixtures/missing_raises.py`
+**When** `check_enrichment` is called
+**Then** it returns exactly the expected `missing-raises` finding
+
+**Given** the `check_enrichment` orchestrator
+**When** called with `source`, `tree`, `config`, `file_path`
+**Then** it returns `list[Finding]` with no I/O and no side effects (pure function)
+
+**FRs:** FR1, FR18, FR19, FR20, FR21, FR24, FR25, FR32, FR37, FR39, FR40, NFR5, NFR6, NFR8, NFR9
+
+### Story 1.5: Missing Yields and Receives Detection
+
+As a developer,
+I want to detect generator functions missing `Yields:` and `Receives:` sections,
+So that consumers of my generators understand what values are yielded and what can be sent in.
+
+**Acceptance Criteria:**
+
+**Given** a generator function with `yield` expressions and a docstring with no `Yields:` section
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-yields"`, `category="required"`
+
+**Given** a generator function with `yield` and a docstring containing a `Yields:` section
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-yields`
+
+**Given** `tests/fixtures/missing_yields.py`
+**When** `check_enrichment` is called
+**Then** it returns exactly the expected `missing-yields` finding
+
+**Given** a generator function using `value = yield` (send pattern) with no `Receives:` section
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-receives"`, `category="required"`
+
+**Given** a generator with `value = yield` and a `Receives:` section present
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-receives`
+
+**Given** `config.require_yields = False`
+**When** `check_enrichment` is called on a generator missing `Yields:`
+**Then** it returns zero findings for `missing-yields`
+
+**Given** `config.require_receives = False`
+**When** `check_enrichment` is called on a generator with send pattern missing `Receives:`
+**Then** it returns zero findings for `missing-receives`
+
+**Given** an async generator function with `yield`
+**When** `check_enrichment` is called
+**Then** it detects the `yield` via `ast.walk` on the `AsyncFunctionDef` body and applies the same rules
+
+**FRs:** FR2, FR3, FR32, NFR5, NFR6
+
+### Story 1.6: Missing Warns and Other Parameters Detection
+
+As a developer,
+I want to detect functions that call `warnings.warn()` without a `Warns:` section and functions with `**kwargs` without an `Other Parameters:` section,
+So that my docstrings fully describe warning behavior and extra keyword arguments.
+
+**Acceptance Criteria:**
+
+**Given** a function calling `warnings.warn()` with no `Warns:` section in its docstring
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-warns"`, `category="required"`
+
+**Given** a function calling `warnings.warn()` with a `Warns:` section present
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-warns`
+
+**Given** `config.require_warns = False`
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-warns`
+
+**Given** a function with `**kwargs` parameter and no `Other Parameters:` section
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-other-parameters"`, `category="recommended"`
+
+**Given** a function with `**kwargs` and an `Other Parameters:` section present
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-other-parameters`
+
+**Given** `config.require_other_parameters = False`
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-other-parameters`
+
+**Given** a function that calls `warnings.warn()` via a qualified path (e.g., `warnings.warn(...)`)
+**When** `check_enrichment` is called
+**Then** it detects the `warn` call via AST `Call` node inspection
+
+**Given** all 5 function-level rules enabled with a function that triggers none of them
+**When** `check_enrichment` is called
+**Then** it returns zero findings for that function
+
+**FRs:** FR4, FR5, FR32, NFR5, NFR10
+
+### Story 1.7: CLI Wiring for Enrichment Check
+
+As a developer,
+I want to run `docvet enrichment` from the command line and see findings in `file:line: rule message` format,
+So that I can integrate enrichment checking into my development workflow and CI pipelines.
+
+**Acceptance Criteria:**
+
+**Given** a codebase with files containing functions missing `Raises:` sections
+**When** `docvet enrichment` is run
+**Then** findings are printed to terminal in `file:line: rule message` format (one per line)
+
+**Given** a codebase with no enrichment issues
+**When** `docvet enrichment` is run
+**Then** it produces no output and exits with code 0
+
+**Given** the existing `_run_enrichment` stub in `cli.py`
+**When** the enrichment check is wired
+**Then** it reads each discovered file, calls `ast.parse()`, and passes `source`, `tree`, `config.enrichment`, and `file_path` to `check_enrichment`
+
+**Given** a file that fails `ast.parse()` with `SyntaxError`
+**When** `docvet enrichment` processes it
+**Then** the file is skipped with a warning (not passed to `check_enrichment`)
+
+**Given** `docvet check` is run (all checks)
+**When** enrichment is in the enabled checks
+**Then** enrichment findings are included alongside findings from other checks
+
+**Given** `docvet enrichment --all` is run on a project
+**When** the run completes
+**Then** all Python files in the project are analyzed (not just git diff files)
+
+**FRs:** FR42, NFR18
+
+---
+
+**Epic 1 Summary:** 7 stories, covering all 30 FRs assigned to this epic. Each story builds on the previous without forward dependencies.
+
+### Epic 2: Class & Module Enrichment Detection
+
+A developer can detect missing `Attributes:` sections across all class-like constructs (plain classes, dataclasses, NamedTuples, TypedDicts) and `__init__.py` modules. The highest-complexity rule with 5 detection branches, first-match-wins deduplication, and dedicated helper functions.
+
+**FRs covered:** FR6, FR7, FR8, FR33, FR34
+
+## Epic 2: Class & Module Enrichment Detection
+
+A developer can detect missing `Attributes:` sections across all class-like constructs (plain classes, dataclasses, NamedTuples, TypedDicts) and `__init__.py` modules. The highest-complexity rule with 5 detection branches, first-match-wins deduplication, and dedicated helper functions.
+
+### Story 2.1: Dataclass, NamedTuple, and TypedDict Attributes Detection
+
+As a developer,
+I want to detect dataclasses, NamedTuples, and TypedDicts that lack an `Attributes:` section,
+So that users of my data structures can see all fields documented in one place.
+
+**Acceptance Criteria:**
+
+**Given** a class decorated with `@dataclass` and a docstring with no `Attributes:` section
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-attributes"`, `category="required"`, and a message naming the class and its field count
+
+**Given** a class decorated with `@dataclasses.dataclass` (qualified form)
+**When** `check_enrichment` is called
+**Then** it detects the dataclass and applies the same rule
+
+**Given** a class decorated with `@dataclass(frozen=True)` (decorator with arguments)
+**When** `check_enrichment` is called
+**Then** it detects the dataclass via `ast.Call` node inspection
+
+**Given** a class inheriting from `NamedTuple` (e.g., `class Foo(NamedTuple):`)
+**When** `check_enrichment` is called and the docstring has no `Attributes:` section
+**Then** it returns a `Finding` with `rule="missing-attributes"`, `category="required"`
+
+**Given** a class inheriting from `typing.NamedTuple` (qualified base class)
+**When** `check_enrichment` is called
+**Then** it detects the NamedTuple via `ast.Attribute` base class inspection
+
+**Given** a class inheriting from `TypedDict`
+**When** `check_enrichment` is called and the docstring has no `Attributes:` section
+**Then** it returns a `Finding` with `rule="missing-attributes"`, `category="required"`
+
+**Given** a dataclass with a docstring containing an `Attributes:` section
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-attributes` on that class
+
+**Given** `config.require_attributes = False`
+**When** `check_enrichment` is called on any class-like construct missing `Attributes:`
+**Then** it returns zero findings for `missing-attributes`
+
+**Given** a dataclass with no docstring at all
+**When** `check_enrichment` is called
+**Then** it returns zero findings (undocumented symbols skipped)
+
+**Given** the `_is_dataclass`, `_is_namedtuple`, and `_is_typeddict` helper functions
+**When** tested directly with AST nodes
+**Then** each correctly identifies its construct type and returns `False` for non-matching nodes
+
+**FRs:** FR7, FR33, NFR5, NFR10
+
+### Story 2.2: Plain Class and `__init__.py` Module Attributes Detection
+
+As a developer,
+I want to detect plain classes with `__init__` self-assignments and `__init__.py` modules that lack `Attributes:` sections,
+So that all class fields and module exports are documented for consumers.
+
+**Acceptance Criteria:**
+
+**Given** a plain class with an `__init__` method containing `self.x = value` assignments and a docstring with no `Attributes:` section
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-attributes"`, `category="required"`
+
+**Given** a plain class with `__init__` containing annotated assignments (`self.x: int = 0`)
+**When** `check_enrichment` is called and the docstring has no `Attributes:` section
+**Then** it detects the self-assignments via `ast.AnnAssign` and returns a finding
+
+**Given** a plain class with `__init__` but no `self.*` assignments
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-attributes` on that class (no fields to document)
+
+**Given** an `__init__.py` module with a module-level docstring but no `Attributes:` section
+**When** `check_enrichment` is called with `file_path` ending in `__init__.py`
+**Then** it returns a `Finding` with `rule="missing-attributes"`, `category="required"`, applied to the module-level symbol
+
+**Given** an `__init__.py` module with an `Attributes:` section in its module docstring
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-attributes`
+
+**Given** a regular Python file (not `__init__.py`) with a module-level docstring
+**When** `check_enrichment` is called
+**Then** it does not apply `__init__.py`-specific rules
+
+**Given** a class that is both a `@dataclass` and has `__init__` self-assignments
+**When** `check_enrichment` is called
+**Then** it produces at most one `missing-attributes` finding (dataclass branch wins per first-match-wins dispatch order)
+
+**Given** the full `_check_missing_attributes` dispatch
+**When** evaluated on any symbol
+**Then** branches are checked in order: dataclass, NamedTuple, TypedDict, plain class, `__init__.py` module — first match wins, no fallthrough
+
+**Given** the `_has_self_assignments` and `_is_init_module` helper functions
+**When** tested directly
+**Then** each correctly identifies its pattern and returns `False` for non-matching inputs
+
+**FRs:** FR6, FR8, FR18, FR33, FR34, NFR5, NFR10
+
+---
+
+**Epic 2 Summary:** 2 stories, covering all 5 FRs assigned to this epic. Story 2.1 handles structured class variants (dataclass, NamedTuple, TypedDict). Story 2.2 adds plain class and module detection, completing the full 5-branch dispatch.
+
+### Epic 3: Format & Recommended Rules
+
+A developer can detect format and style improvements — missing `Examples:` sections (configurable by symbol type), untyped `Attributes:` format, missing cross-references, and doctest-to-fenced-code-block preferences. Enables required vs recommended triage for codebase sweeps.
+
+**FRs covered:** FR9, FR10, FR11, FR12, FR13, FR14, FR27
+
+## Epic 3: Format & Recommended Rules
+
+A developer can detect format and style improvements — missing `Examples:` sections (configurable by symbol type), untyped `Attributes:` format, missing cross-references, and doctest-to-fenced-code-block preferences. Enables required vs recommended triage for codebase sweeps.
+
+### Story 3.1: Missing Examples Detection
+
+As a developer,
+I want to detect public symbols and `__init__.py` modules that lack an `Examples:` section,
+So that key API surfaces include usage examples for consumers.
+
+**Acceptance Criteria:**
+
+**Given** a class with a docstring and no `Examples:` section, and `config.require_examples = ["class"]`
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-examples"`, `category="recommended"`
+
+**Given** a protocol with a docstring and no `Examples:` section, and `config.require_examples = ["protocol"]`
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-examples"`, `category="recommended"`
+
+**Given** a class with a docstring and no `Examples:` section, and `config.require_examples = ["dataclass"]` (class not in list)
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-examples` on that class
+
+**Given** `config.require_examples = []` (empty list)
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-examples` on any symbol (rule fully disabled)
+
+**Given** the default config (`require_examples = ["class", "protocol", "dataclass", "enum"]`)
+**When** `check_enrichment` is called on a dataclass with no `Examples:` section
+**Then** it returns a `Finding` for `missing-examples`
+
+**Given** a symbol with a docstring containing an `Examples:` section
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-examples` on that symbol
+
+**Given** an `__init__.py` module with a module-level docstring and no `Examples:` section
+**When** `check_enrichment` is called with `file_path` ending in `__init__.py` and `require_examples` is non-empty
+**Then** it returns a `Finding` with `rule="missing-examples"` for the module-level symbol
+
+**Given** a symbol with no docstring
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-examples` (undocumented symbols skipped)
+
+**FRs:** FR9, FR10, FR27, NFR5, NFR10
+
+### Story 3.2: Format and Cross-Reference Rules
+
+As a developer,
+I want to detect untyped `Attributes:` sections, missing cross-reference syntax in `See Also:` sections, missing `See Also:` on `__init__.py` modules, and `Examples:` using doctest format instead of fenced code blocks,
+So that my docstrings follow best practices for readability and mkdocs rendering.
+
+**Acceptance Criteria:**
+
+**Given** a class with an `Attributes:` section using `name: description` format (no type)
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-typed-attributes"`, `category="recommended"`
+
+**Given** a class with an `Attributes:` section using `name (type): description` format
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-typed-attributes`
+
+**Given** `config.require_typed_attributes = False`
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-typed-attributes`
+
+**Given** a symbol with a `See Also:` section that lacks cross-reference syntax
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="missing-cross-references"`, `category="recommended"`
+
+**Given** `config.require_cross_references = False`
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `missing-cross-references`
+
+**Given** an `__init__.py` module with a module-level docstring and no `See Also:` section
+**When** `check_enrichment` is called with `file_path` ending in `__init__.py`
+**Then** it returns a `Finding` with `rule="missing-cross-references"` for the module-level symbol
+
+**Given** a regular Python file (not `__init__.py`) with no `See Also:` section
+**When** `check_enrichment` is called
+**Then** it does not produce a `missing-cross-references` finding for the module-level symbol
+
+**Given** a symbol with an `Examples:` section using `>>>` doctest format
+**When** `check_enrichment` is called
+**Then** it returns a `Finding` with `rule="prefer-fenced-code-blocks"`, `category="recommended"`
+
+**Given** a symbol with an `Examples:` section using fenced code blocks (triple backticks)
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `prefer-fenced-code-blocks`
+
+**Given** `config.prefer_fenced_code_blocks = False`
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `prefer-fenced-code-blocks`
+
+**Given** a symbol with no `Examples:` section at all
+**When** `check_enrichment` is called
+**Then** it returns zero findings for `prefer-fenced-code-blocks` (rule only applies when `Examples:` exists)
+
+**FRs:** FR11, FR12, FR13, FR14, NFR5, NFR10
+
+---
+
+**Epic 3 Summary:** 2 stories, covering all 7 FRs assigned to this epic. Story 3.1 handles the list-config `missing-examples` rule. Story 3.2 covers the remaining docstring-only format and cross-reference rules.

--- a/_bmad-output/planning-artifacts/implementation-readiness-report-2026-02-08.md
+++ b/_bmad-output/planning-artifacts/implementation-readiness-report-2026-02-08.md
@@ -1,0 +1,420 @@
+---
+stepsCompleted:
+  - 'step-01-document-discovery'
+  - 'step-02-prd-analysis'
+  - 'step-03-epic-coverage-validation'
+  - 'step-04-ux-alignment'
+  - 'step-05-epic-quality-review'
+  - 'step-06-final-assessment'
+inputDocuments:
+  - '_bmad-output/planning-artifacts/prd.md'
+  - '_bmad-output/planning-artifacts/architecture.md'
+  - '_bmad-output/planning-artifacts/epics.md'
+  - '_bmad-output/planning-artifacts/prd-validation-report.md'
+status: 'complete'
+project_name: 'docvet'
+date: '2026-02-08'
+---
+
+# Implementation Readiness Assessment Report
+
+**Date:** 2026-02-08
+**Project:** docvet
+
+## Document Inventory
+
+| Document | File | Status |
+|----------|------|--------|
+| PRD | `prd.md` | Complete (506 lines) |
+| PRD Validation Report | `prd-validation-report.md` | Complete (supplementary) |
+| Architecture | `architecture.md` | Complete (734 lines) |
+| Epics & Stories | `epics.md` | Complete (3 epics, 11 stories) |
+| UX Design | N/A | Not applicable (CLI tool) |
+
+**Duplicates:** None
+**Missing Documents:** None (UX absence expected for CLI tool)
+
+## PRD Analysis
+
+### Functional Requirements
+
+**Section Detection (FR1-FR15):**
+
+- FR1: The system can detect functions and methods that contain `raise` statements but lack a `Raises:` section in their docstring
+- FR2: The system can detect generator functions that contain `yield` expressions but lack a `Yields:` section in their docstring
+- FR3: The system can detect generators that use the `value = yield` send pattern but lack a `Receives:` section in their docstring
+- FR4: The system can detect functions that call `warnings.warn()` but lack a `Warns:` section in their docstring
+- FR5: The system can detect functions with `**kwargs` parameters but lack an `Other Parameters:` section in their docstring
+- FR6: The system can detect classes with `__init__` self-assignments that lack an `Attributes:` section in their docstring
+- FR7: The system can detect dataclasses, NamedTuples, and TypedDicts with fields that lack an `Attributes:` section in their docstring
+- FR8: The system can detect `__init__.py` modules that lack an `Attributes:` section documenting their exports
+- FR9: The system can detect public symbols (configurable by type) that lack an `Examples:` section in their docstring
+- FR10: The system can detect `__init__.py` modules that lack an `Examples:` section in their docstring
+- FR11: The system can detect `Attributes:` sections that lack typed format (`name (type): description`)
+- FR12: The system can detect `See Also:` sections that lack cross-reference syntax
+- FR13: The system can detect `__init__.py` modules that lack a `See Also:` section in their docstring
+- FR14: The system can detect `Examples:` sections that use `>>>` doctest format instead of fenced code blocks
+- FR15: The system can recognize `Args:` and `Returns:` section headers for docstring parsing context without checking for their absence
+
+**Finding Production (FR16-FR22):**
+
+- FR16: The system can produce a structured finding for each detected issue, carrying file path, line number, symbol name, rule identifier, human-readable message, and category
+- FR17: The system can categorize each finding as `required` or `recommended` based on the rule definition
+- FR18: The system can produce at most one finding per symbol per rule, even when multiple detection branches match the same symbol
+- FR19: The system can produce zero findings when analyzing well-documented code with complete docstrings
+- FR20: The system can produce zero findings for symbols that have no docstring
+- FR21: The system can produce findings only for missing sections, not for sections that exist but are incomplete
+- FR22: The system can provide Finding as an immutable (frozen) dataclass that cannot be modified after creation
+
+**Rule Management (FR23-FR25):**
+
+- FR23: The system can identify each finding with a stable, human-readable kebab-case rule identifier
+- FR24: A developer can reference rule identifiers in configuration, output filtering, and issue tracking
+- FR25: The system can map 14 detection scenarios to 10 distinct rule identifiers
+
+**Configuration (FR26-FR31):**
+
+- FR26: A developer can enable or disable each of the 10 rules independently via boolean toggles
+- FR27: A developer can configure which symbol types trigger the `missing-examples` rule via a list
+- FR28: The system can validate `require-examples` entries against known symbol types
+- FR29: A developer can disable all enrichment findings via config
+- FR30: The system can apply defaults when no enrichment configuration is provided
+- FR31: The system can recognize 8 Google-style section headers for missing section detection
+
+**Symbol Analysis (FR32-FR38):**
+
+- FR32: The system can analyze function and method symbols for raise/yield/warn/kwargs patterns
+- FR33: The system can analyze class symbols to determine construct type
+- FR34: The system can analyze module symbols to determine if the source file is an `__init__.py`
+- FR35: The system can extract and parse raw docstring text from symbols
+- FR36: The system can analyze any symbol with a non-empty docstring
+- FR37: The system can distinguish documented vs undocumented symbols
+- FR38: The system can process malformed docstrings without raising exceptions
+
+**Integration (FR39-FR42):**
+
+- FR39: The system can accept source, AST, config, file_path as inputs and return findings list
+- FR40: The system can operate as a pure function with no I/O, no side effects
+- FR41: The system can provide Finding as a shared type for all check modules
+- FR42: A developer can run enrichment standalone or as part of `docvet check`
+
+**Total FRs: 42**
+
+### Non-Functional Requirements
+
+**Performance (NFR1-NFR4):**
+
+- NFR1: Single file analysis in under 50ms (aspirational)
+- NFR2: 200-file codebase in under 5 seconds (aspirational)
+- NFR3: No measurable overhead beyond AST parsing
+- NFR4: Linear memory scaling with file count
+
+**Correctness (NFR5-NFR9):**
+
+- NFR5: Zero false positives on well-documented code
+- NFR6: Identical output for identical input (deterministic)
+- NFR7: Malformed docstrings produce zero findings, never crash
+- NFR8: Never modifies input data
+- NFR9: Actionable finding messages
+
+**Maintainability (NFR10-NFR13):**
+
+- NFR10: Each rule independently understandable and testable
+- NFR11: New rule requires at most 3-file change
+- NFR12: >=90% coverage on enrichment.py (aspirational)
+- NFR13: All quality gates pass (ruff, ty, pytest, interrogate)
+
+**Compatibility (NFR14-NFR16):**
+
+- NFR14: Python 3.12 and 3.13
+- NFR15: Linux, macOS, Windows
+- NFR16: No new runtime dependencies
+
+**Integration (NFR17-NFR19):**
+
+- NFR17: Finding 6-field shape stable for v1
+- NFR18: Integrates with existing CLI dispatch pattern
+- NFR19: Config additions backward-compatible
+
+**Total NFRs: 19**
+
+### Additional Requirements
+
+From Architecture document:
+- Prerequisite PR 1: `require_attributes` config toggle
+- Prerequisite PR 2: `checks/__init__.py` with `Finding` dataclass
+- 7-step implementation sequence with cross-decision dependencies
+- `missing-attributes` 5-branch dispatch order is an architectural constraint
+- Config gating in orchestrator, not in `_check_*` functions
+- Defensive error handling: no try/except in MVP
+- Dual testing strategy for simple vs complex rules
+
+From PRD Validation Report:
+- FR12 "cross-reference syntax" never formally defined (weakest FR)
+- FR8 "exports" in `__init__.py` context ambiguous
+- Decorator alias detection explicitly out of MVP scope
+
+### PRD Completeness Assessment
+
+The PRD is comprehensive with 42 FRs and 19 NFRs across well-organized categories. The PRD validation report rated it 4.5/5 with PASS_WITH_WARNINGS status. Key strengths: zero information density violations, 100% CLI tool compliance, strong SMART scores (4.73/5.0 average). Minor gaps: FR12 cross-reference syntax undefined, 4 rules undemonstrated in user journeys.
+
+## Epic Coverage Validation
+
+### Coverage Matrix
+
+| FR | PRD Requirement | Epic | Story | Status |
+|----|----------------|------|-------|--------|
+| FR1 | Detect missing Raises section | Epic 1 | 1.4 | Covered |
+| FR2 | Detect missing Yields section | Epic 1 | 1.5 | Covered |
+| FR3 | Detect missing Receives section | Epic 1 | 1.5 | Covered |
+| FR4 | Detect missing Warns section | Epic 1 | 1.6 | Covered |
+| FR5 | Detect missing Other Parameters section | Epic 1 | 1.6 | Covered |
+| FR6 | Detect missing Attributes on plain classes | Epic 2 | 2.2 | Covered |
+| FR7 | Detect missing Attributes on dataclasses/NamedTuples/TypedDicts | Epic 2 | 2.1 | Covered |
+| FR8 | Detect missing Attributes on `__init__.py` modules | Epic 2 | 2.2 | Covered |
+| FR9 | Detect missing Examples on configurable symbol types | Epic 3 | 3.1 | Covered |
+| FR10 | Detect missing Examples on `__init__.py` modules | Epic 3 | 3.1 | Covered |
+| FR11 | Detect untyped Attributes format | Epic 3 | 3.2 | Covered |
+| FR12 | Detect missing cross-reference syntax in See Also | Epic 3 | 3.2 | Covered |
+| FR13 | Detect missing See Also on `__init__.py` modules | Epic 3 | 3.2 | Covered |
+| FR14 | Detect doctest format instead of fenced code blocks | Epic 3 | 3.2 | Covered |
+| FR15 | Recognize Args/Returns headers for parsing context | Epic 1 | 1.3 | Covered |
+| FR16 | Finding dataclass with 6 fields | Epic 1 | 1.2 | Covered |
+| FR17 | Finding category (required/recommended) | Epic 1 | 1.2 | Covered |
+| FR18 | One finding per symbol per rule deduplication | Epic 1, 2 | 1.4, 2.2 | Covered |
+| FR19 | Zero findings on clean code | Epic 1 | 1.4 | Covered |
+| FR20 | Zero findings for undocumented symbols | Epic 1 | 1.4 | Covered |
+| FR21 | Missing-only detection (not incomplete) | Epic 1 | 1.4 | Covered |
+| FR22 | Finding is frozen/immutable | Epic 1 | 1.2 | Covered |
+| FR23 | Kebab-case rule identifiers | Epic 1 | 1.2 | Covered |
+| FR24 | Rule IDs usable in config/filtering/tracking | Epic 1 | 1.4 | Covered |
+| FR25 | 14 scenarios -> 10 rule ID mapping | Epic 1 | 1.4 | Covered |
+| FR26 | Per-rule boolean config toggles | Epic 1 | 1.1 | Covered |
+| FR27 | `require-examples` list config | Epic 3 | 3.1 | Covered |
+| FR28 | Validate `require-examples` entries | Epic 1 | 1.1 | Covered |
+| FR29 | Disable all findings via config | Epic 1 | 1.1 | Covered |
+| FR30 | Sensible defaults when no config provided | Epic 1 | 1.1 | Covered |
+| FR31 | Recognize 8 Google-style section headers | Epic 1 | 1.3 | Covered |
+| FR32 | Analyze functions for raise/yield/warn/kwargs patterns | Epic 1 | 1.4, 1.5, 1.6 | Covered |
+| FR33 | Analyze class construct types | Epic 2 | 2.1, 2.2 | Covered |
+| FR34 | Analyze module symbols for `__init__.py` | Epic 2 | 2.2 | Covered |
+| FR35 | Extract and parse docstring sections | Epic 1 | 1.3 | Covered |
+| FR36 | Analyze any symbol with non-empty docstring | Epic 1 | 1.3 | Covered |
+| FR37 | Distinguish documented vs undocumented symbols | Epic 1 | 1.4 | Covered |
+| FR38 | Handle malformed docstrings gracefully | Epic 1 | 1.3 | Covered |
+| FR39 | Pure function API: source, tree, config, file_path -> findings | Epic 1 | 1.4 | Covered |
+| FR40 | No I/O, no side effects, deterministic | Epic 1 | 1.4 | Covered |
+| FR41 | Finding as shared type for all check modules | Epic 1 | 1.2 | Covered |
+| FR42 | CLI wiring: `docvet enrichment` and `docvet check` | Epic 1 | 1.7 | Covered |
+
+### Missing Requirements
+
+No missing FRs. All 42 functional requirements are covered by at least one story with testable acceptance criteria.
+
+### Coverage Statistics
+
+- Total PRD FRs: 42
+- FRs covered in epics: 42
+- Coverage percentage: **100%**
+- FRs in epics but not in PRD: 0 (no phantom requirements)
+
+## UX Alignment Assessment
+
+### UX Document Status
+
+**Not Found** — No UX design document exists.
+
+### UX Implied?
+
+**No.** docvet is a non-interactive CLI tool (`projectType: cli_tool`). The PRD explicitly states it follows the tradition of ruff, ty, and interrogate — scriptable, non-interactive, terminal output only. No user interface, no web/mobile components, no interactive elements.
+
+### Alignment Issues
+
+None. UX documentation is not applicable for this project type.
+
+### Warnings
+
+None. The PRD project-type compliance validation confirmed 0 excluded UX sections present (clean). The architecture document confirms single-process CLI pipeline with no UI components.
+
+## Epic Quality Review
+
+### Epic Structure Validation
+
+#### A. User Value Focus Check
+
+| Epic | Title | User-Centric? | User Outcome | Standalone Value? |
+|------|-------|---------------|-------------|-------------------|
+| Epic 1 | Function-Level Enrichment Detection | Yes | Developer runs `docvet enrichment` and gets findings for missing sections on functions/methods | Yes — end-to-end CLI tool for function-level checks |
+| Epic 2 | Class & Module Enrichment Detection | Yes | Developer detects missing `Attributes:` on classes, dataclasses, NamedTuples, TypedDicts, and modules | Yes — extends Epic 1's detection to class-like constructs |
+| Epic 3 | Format & Recommended Rules | Yes | Developer detects format/style improvements and triages required vs recommended | Yes — adds recommended category rules |
+
+**Assessment:** All 3 epics describe user outcomes, not technical milestones. No "Setup Database", "Create Models", or "Infrastructure Setup" anti-patterns detected.
+
+**One nuance:** Stories 1.1 (config toggle) and 1.2 (Finding dataclass) within Epic 1 are infrastructure-flavored prerequisites. However, they are correctly placed *within* an epic that delivers end-to-end user value, not isolated as a standalone "Foundation" epic. This was an explicit design decision — the original 5-epic proposal had a separate "Check Module Foundation" epic which was correctly consolidated during epic design review.
+
+#### B. Epic Independence Validation
+
+| Test | Result | Notes |
+|------|--------|-------|
+| Epic 1 standalone? | **Pass** | Delivers function-level detection + CLI wiring end-to-end |
+| Epic 2 without Epic 3? | **Pass** | `missing-attributes` works independently — no format rules needed |
+| Epic 3 without Epic 2? | **Pass** | Format rules are docstring-only, no dependency on class detection |
+| Epic 2 requires Epic 1? | **Yes (expected)** | Plugs `_check_missing_attributes` into Epic 1's orchestrator |
+| Epic 3 requires Epic 1? | **Yes (expected)** | Plugs format rules into Epic 1's orchestrator |
+| Circular dependencies? | **None** | Linear dependency: Epic 1 -> Epic 2, Epic 1 -> Epic 3 |
+
+**Assessment:** Pass. No reverse or circular dependencies. Epics 2 and 3 are independent of each other.
+
+### Story Quality Assessment
+
+#### A. Story Sizing Validation
+
+| Story | Size | Single Dev? | Clear Value? | Notes |
+|-------|------|-------------|-------------|-------|
+| 1.1 | Small | Yes | Config prerequisite | Infrastructure, but scoped correctly |
+| 1.2 | Small | Yes | Type contract prerequisite | Infrastructure, but scoped correctly |
+| 1.3 | Medium | Yes | Parser + index infrastructure | Enables all detection rules |
+| 1.4 | Large | Yes | First detection rule + orchestrator | Highest-risk story — double duty |
+| 1.5 | Medium | Yes | Generator detection | Adds 2 rules to existing orchestrator |
+| 1.6 | Medium | Yes | Warns + kwargs detection | Adds 2 rules to existing orchestrator |
+| 1.7 | Small-Medium | Yes | CLI entry point | Makes everything user-accessible |
+| 2.1 | Medium | Yes | Structured class detection | 3 detection helpers |
+| 2.2 | Medium-Large | Yes | Plain class + module detection | Nested walk + dedup integration test |
+| 3.1 | Medium | Yes | Examples detection | List-config rule |
+| 3.2 | Medium | Yes | Format/cross-ref rules | 4 docstring-only rules |
+
+**Assessment:** Pass. No oversized stories. Story 1.4 is the largest but remains within single-dev scope — it's the architectural spine that enables all subsequent rules.
+
+#### B. Acceptance Criteria Review
+
+| Criterion | Status | Notes |
+|-----------|--------|-------|
+| Given/When/Then format | **Pass** | All 11 stories use consistent BDD structure |
+| Independently testable | **Pass** | Each AC maps to a distinct test case |
+| Error conditions covered | **Pass** | Config disabled, no docstring, malformed docstring, SyntaxError file |
+| Specific expected outcomes | **Pass** | Rule names, category values, zero-finding guarantees all explicit |
+
+**Minor concerns:**
+- Story 3.2 AC for `missing-cross-references`: "lacks cross-reference syntax" — the AC inherits the PRD's FR12 weakness (cross-reference syntax never formally defined). The tech spec must define what constitutes valid cross-reference syntax before implementation.
+- Story 2.2 AC for `__init__.py` Attributes: "exports" is not defined — inherits FR8 ambiguity from PRD. Tech spec must clarify.
+
+### Dependency Analysis
+
+#### A. Within-Epic Dependencies
+
+**Epic 1 (7 stories):**
+- 1.1: Standalone (config.py modification) — **Pass**
+- 1.2: Standalone (new file, no dependency on 1.1) — **Pass**
+- 1.3: Standalone (new functions in enrichment.py, imports Finding from 1.2) — **Pass**
+- 1.4: Depends on 1.2 (Finding) and 1.3 (parser, index) — **Pass** (backward only)
+- 1.5: Depends on 1.4 (orchestrator exists) — **Pass** (backward only)
+- 1.6: Depends on 1.4 (orchestrator exists) — **Pass** (backward only)
+- 1.7: Depends on 1.4+ (orchestrator + rules exist) — **Pass** (backward only)
+
+**No forward dependencies detected.**
+
+**Epic 2 (2 stories):**
+- 2.1: Depends on Epic 1 orchestrator — **Pass** (cross-epic backward only)
+- 2.2: Depends on 2.1 (helpers exist, completes 5-branch dispatch) — **Pass** (backward only)
+
+**Epic 3 (2 stories):**
+- 3.1: Depends on Epic 1 orchestrator — **Pass** (cross-epic backward only)
+- 3.2: Depends on Epic 1 orchestrator — **Pass** (backward only, independent of 3.1)
+
+**No forward dependencies detected across any epic.**
+
+#### B. Database/Entity Creation Timing
+
+**N/A** — No database. CLI tool with in-memory AST processing. No persistent state.
+
+### Special Implementation Checks
+
+#### A. Starter Template Requirement
+
+Architecture does **not** specify a starter template. Project is brownfield with existing scaffolding. **N/A.**
+
+#### B. Greenfield vs Brownfield
+
+**Brownfield confirmed.** Architecture document states `projectContext: brownfield`. Existing infrastructure: `ast_utils.py`, `config.py`, `cli.py` with `_run_enrichment` stub, `discovery.py`, test fixtures. Stories correctly build on existing code rather than creating project from scratch.
+
+### Best Practices Compliance Checklist
+
+| Check | Epic 1 | Epic 2 | Epic 3 |
+|-------|--------|--------|--------|
+| Delivers user value | Yes | Yes | Yes |
+| Functions independently | Yes | Yes (with E1) | Yes (with E1) |
+| Stories appropriately sized | Yes | Yes | Yes |
+| No forward dependencies | Yes | Yes | Yes |
+| DB tables created when needed | N/A | N/A | N/A |
+| Clear acceptance criteria | Yes | Yes | Yes |
+| FR traceability maintained | Yes | Yes | Yes |
+
+### Quality Findings Summary
+
+#### Critical Violations
+
+**None.**
+
+#### Major Issues
+
+**None.**
+
+#### Minor Concerns
+
+1. **FR12 cross-reference syntax undefined** (inherited from PRD) — Story 3.2 AC says "lacks cross-reference syntax" without defining what valid syntax looks like. Tech spec must resolve before implementation. **Severity: Minor** — does not block implementation of other stories.
+
+2. **FR8 "exports" ambiguous** (inherited from PRD) — Story 2.2 AC for `__init__.py` modules. Tech spec must clarify whether "exports" means `__all__`, public names, or both. **Severity: Minor** — does not block implementation of other stories.
+
+3. **Story 1.4 risk concentration** — This story establishes both the orchestrator pattern AND the first detection rule. If the orchestrator design needs revision, all subsequent stories are impacted. **Severity: Minor** — mitigated by thorough architecture document with code examples.
+
+### Recommendations
+
+1. Resolve FR12 and FR8 ambiguities in tech specs for Stories 3.2 and 2.2 respectively, before those stories enter implementation.
+2. Story 1.4 should receive the most PR review scrutiny — it establishes the pattern all other stories follow.
+3. No structural changes needed to the epic/story breakdown.
+
+## Summary and Recommendations
+
+### Overall Readiness Status
+
+**READY**
+
+### Assessment Summary
+
+| Category | Result |
+|----------|--------|
+| Document Inventory | 4/4 documents found, no duplicates |
+| PRD Analysis | 42 FRs + 19 NFRs extracted, well-organized |
+| FR Coverage | 42/42 FRs covered (100%) |
+| UX Alignment | N/A (CLI tool, no UI) |
+| Epic User Value | All 3 epics deliver user outcomes |
+| Epic Independence | No circular or reverse dependencies |
+| Story Dependencies | No forward dependencies detected |
+| Story Sizing | All stories completable by single dev |
+| Acceptance Criteria | BDD format, testable, specific |
+| Critical Violations | 0 |
+| Major Issues | 0 |
+| Minor Concerns | 3 |
+
+### Critical Issues Requiring Immediate Action
+
+**None.** No blockers to implementation.
+
+### Minor Issues (addressable during implementation)
+
+1. **FR12 cross-reference syntax undefined** — Tech spec for Story 3.2 must define what constitutes valid cross-reference syntax before that story enters development. Does not block Epic 1 or Epic 2.
+
+2. **FR8 "exports" ambiguous** — Tech spec for Story 2.2 must clarify whether `__init__.py` "exports" means `__all__`, public names, or both. Does not block Epic 1.
+
+3. **Story 1.4 risk concentration** — Establishes both orchestrator pattern and first detection rule. Mitigated by architecture document with code examples. Recommend prioritizing PR review scrutiny on this story.
+
+### Recommended Next Steps
+
+1. **Proceed to Sprint Planning** (`/bmad-bmm-sprint-planning`) — all planning artifacts are aligned and ready
+2. **Resolve FR12 and FR8 ambiguities** in tech specs when Stories 2.2 and 3.2 are prepared for development (not blocking — Epics 2 and 3 are downstream of Epic 1)
+3. **Ship prerequisite PRs first** (Stories 1.1 and 1.2) — small, isolated changes that establish the contracts all other stories depend on
+4. **Apply extra review scrutiny to Story 1.4** — the orchestrator pattern it establishes is the architectural spine for all 10 rules
+
+### Final Note
+
+This assessment identified 0 critical issues and 3 minor concerns across 6 validation categories. The planning artifacts (PRD, Architecture, Epics & Stories) are well-aligned with 100% FR coverage, proper epic independence, no forward dependencies, and consistently testable acceptance criteria. The project is ready to proceed to implementation.

--- a/_bmad-output/planning-artifacts/prd-validation-report.md
+++ b/_bmad-output/planning-artifacts/prd-validation-report.md
@@ -1,0 +1,403 @@
+---
+validationTarget: '_bmad-output/planning-artifacts/prd.md'
+validationDate: '2026-02-08'
+inputDocuments:
+  - '_bmad-output/project-context.md'
+  - 'docs/product-vision.md'
+  - 'docs/architecture.md'
+  - 'docs/project-overview.md'
+  - 'docs/development-guide.md'
+  - 'docs/source-tree-analysis.md'
+  - 'docs/index.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-4-cli-scaffold.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-ci-workflow.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-config-reader.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-file-discovery.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-7-ast-helpers.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-wire-discovery-cli.md'
+  - 'gh-issue-8'
+validationStepsCompleted:
+  - 'step-v-01-discovery'
+  - 'step-v-02-format-detection'
+  - 'step-v-03-density-validation'
+  - 'step-v-04-brief-coverage-skipped'
+  - 'step-v-05-measurability-validation'
+  - 'step-v-06-traceability-validation'
+  - 'step-v-07-implementation-leakage-validation'
+  - 'step-v-08-domain-compliance-skipped'
+  - 'step-v-09-project-type-validation'
+  - 'step-v-10-smart-validation'
+  - 'step-v-11-holistic-quality-validation'
+  - 'step-v-12-completeness-validation'
+  - 'step-v-13-report-complete'
+validationStatus: COMPLETE
+holisticQualityRating: '4.5/5'
+overallStatus: PASS_WITH_WARNINGS
+---
+
+# PRD Validation Report
+
+**PRD Being Validated:** _bmad-output/planning-artifacts/prd.md
+**Validation Date:** 2026-02-08
+
+## Input Documents
+
+- _bmad-output/project-context.md (146 lines)
+- docs/product-vision.md (253 lines)
+- docs/architecture.md (137 lines)
+- docs/project-overview.md (61 lines)
+- docs/development-guide.md (221 lines)
+- docs/source-tree-analysis.md (119 lines)
+- docs/index.md (40 lines)
+- _bmad-output/implementation-artifacts/tech-spec-4-cli-scaffold.md (238 lines)
+- _bmad-output/implementation-artifacts/tech-spec-ci-workflow.md (183 lines)
+- _bmad-output/implementation-artifacts/tech-spec-config-reader.md (353 lines)
+- _bmad-output/implementation-artifacts/tech-spec-file-discovery.md (350 lines)
+- _bmad-output/implementation-artifacts/tech-spec-7-ast-helpers.md (229 lines)
+- _bmad-output/implementation-artifacts/tech-spec-wire-discovery-cli.md (337 lines)
+- GitHub Issue #8 (fetched via CLI)
+
+## Validation Findings
+
+## Format Detection
+
+**PRD Structure (## Level 2 headers):**
+
+1. Executive Summary
+2. Success Criteria
+3. Product Scope
+4. User Journeys
+5. CLI Tool Specific Requirements
+6. Project Scoping & Phased Development
+7. Functional Requirements
+8. Non-Functional Requirements
+
+**BMAD Core Sections Present:**
+- Executive Summary: Present
+- Success Criteria: Present
+- Product Scope: Present
+- User Journeys: Present
+- Functional Requirements: Present
+- Non-Functional Requirements: Present
+
+**Format Classification:** BMAD Standard
+**Core Sections Present:** 6/6
+
+## Information Density Validation
+
+**Anti-Pattern Violations:**
+
+**Conversational Filler:** 0 occurrences
+
+**Wordy Phrases:** 0 occurrences
+
+**Redundant Phrases:** 0 occurrences
+
+**Total Violations:** 0
+
+**Severity Assessment:** Pass
+
+**Recommendation:** PRD demonstrates good information density with minimal violations. Writing is direct and concise throughout — FRs use clean "The system can..." phrasing, technical prose uses dashes and parentheticals over wordy clauses, and config/API sections are structured as specs with code blocks and tables.
+
+## Product Brief Coverage
+
+**Status:** N/A - No Product Brief was provided as input (documentCounts.briefs: 0)
+
+## Measurability Validation
+
+### Functional Requirements
+
+**Total FRs Analyzed:** 42
+
+**Format Violations:** 0
+All FRs follow "The system can [capability]" or "A developer can [capability]" consistently.
+
+**Subjective Adjectives Found:** 2
+- FR30 (line 451): "sensible defaults" — mitigated by immediate clarification "(all rules enabled)"
+- FR38 (line 462): "gracefully handle" — mitigated by "without crashing or producing false findings"
+
+**Vague Quantifiers Found:** 1
+- FR18 (line 433): "multiple detection branches" — borderline; the measurable criterion "at most one finding per symbol per rule" is clearly stated
+
+**Implementation Leakage:** 0
+All technology references (`ast`, `re`, `warnings.warn()`, `dataclass`, `NamedTuple`, `TypedDict`, Google-style) are capability-relevant.
+
+**FR Violations Total:** 3
+
+### Non-Functional Requirements
+
+**Total NFRs Analyzed:** 19
+
+**Missing Metrics:** 2
+- NFR3 (line 477): "no measurable overhead" lacks a threshold — what counts as measurable?
+- NFR10 (line 490): "without knowledge of other rules" is a design aspiration, not directly measurable
+
+**Incomplete Template:** 0
+
+**Missing Context:** 0
+
+**NFR Violations Total:** 2
+
+### Overall Assessment
+
+**Total Requirements:** 61 (42 FRs + 19 NFRs)
+**Total Violations:** 5
+
+**Severity:** Warning (5-10 range)
+
+**Recommendation:** All 5 violations are minor — subjective adjectives are immediately clarified with testable behavior in the same sentence, and the 2 NFR metric gaps are inherent design aspirations. PRD demonstrates strong measurability overall. No critical gaps requiring revision.
+
+## Traceability Validation
+
+### Chain Validation
+
+**Executive Summary → Success Criteria:** Intact — all vision elements (ecosystem gap, AST detection, 10 rules/14 scenarios, required/recommended, config customization) have corresponding success criteria.
+
+**Success Criteria → User Journeys:** Intact — all user/business success criteria are demonstrated by at least one journey. Technical/measurable criteria are appropriately internal.
+
+**User Journeys → Functional Requirements:** Intact with acknowledged warnings — all enrichment-module capabilities have supporting FRs. CLI/reporting capabilities (exit codes, summary line, warn-on/fail-on) are explicitly acknowledged as out of enrichment scope (line 234).
+
+**Scope → FR Alignment:** Intact — all MVP scope items map to FRs.
+
+### Orphan Elements
+
+**Orphan Functional Requirements:** 0 (true orphans)
+
+All FRs trace to at least one success criterion. However, 7 FRs (FR3, FR5, FR8, FR10, FR12, FR13, FR14) lack direct journey demonstration — they trace only to BS4/TS3 ("all 14 scenarios ship together"). These are journeyed-by-proxy, not orphaned.
+
+**Unsupported Success Criteria:** 0
+
+**User Journeys Without FRs:** 0 (for enrichment scope)
+
+3 journey capabilities lack enrichment-module FRs (warn-on/fail-on, exit codes, summary line) — documented as CLI/reporting layer dependencies at line 234.
+
+### Journey-to-Rule Coverage
+
+Rules demonstrated in at least one journey: `missing-raises`, `missing-yields`, `missing-warns`, `missing-attributes`, `missing-typed-attributes`, `missing-examples` (6/10)
+
+Rules never demonstrated in any journey: `missing-receives`, `missing-other-parameters`, `missing-cross-references`, `prefer-fenced-code-blocks` (4/10)
+
+### Traceability Summary
+
+| Chain | Status |
+|-------|--------|
+| Exec Summary → Success Criteria | Intact |
+| Success Criteria → User Journeys | Intact |
+| User Journeys → FRs | Intact (with acknowledged CLI scope boundary) |
+| MVP Scope → FRs | Intact |
+
+**Total Traceability Issues:** 3 warnings (all acknowledged/minor)
+
+**Severity:** Pass (with warnings)
+
+**Recommendation:** Traceability chain is intact. The 4 undemonstrated rules (FR3, FR5, FR12, FR14) trace to success criteria but lack narrative proof — consider noting these are journeyed-by-proxy via BS4. CLI/reporting dependencies are well-documented as out-of-scope for the enrichment module.
+
+## Implementation Leakage Validation
+
+### Leakage by Category
+
+**Frontend Frameworks:** 0 violations
+**Backend Frameworks:** 0 violations
+**Databases:** 0 violations
+**Cloud Platforms:** 0 violations
+**Infrastructure:** 0 violations
+**Libraries:** 0 violations
+
+**Implementation Technique Leakage:** 1 violation
+- NFR3 (line 477): "section detection uses string matching and AST traversal" — prescribes implementation technique inside a performance requirement. The WHAT is "no measurable overhead"; the HOW is "string matching and AST traversal."
+
+**Implementation Pattern Leakage:** 2 borderline violations
+- FR22 (line 437): "frozen dataclass" — prescribes `@dataclass(frozen=True)` mechanism. The WHAT is immutability; "frozen dataclass" is HOW.
+- FR40 (line 467): "pure function" — prescribes implementation shape. The WHAT is "deterministic output, no I/O, no side effects."
+
+### Summary
+
+**Total Implementation Leakage Violations:** 3 (1 definite + 2 borderline)
+
+**Severity:** Warning (2-5 range)
+
+**Recommendation:** The PRD is largely clean — zero framework/platform/library leakage. The 3 findings are minor: NFR3's technique description could be moved to a design note, while FR22 and FR40 use implementation terms as intentional precision constraints. No critical leakage requiring revision.
+
+**Note:** 25+ technology terms were evaluated and classified as capability-relevant (Python constructs, docstring standards, config format, tooling references). These are appropriate in a CLI tool PRD that must understand these constructs to function.
+
+## Domain Compliance Validation
+
+**Domain:** developer_tooling
+**Complexity:** Low (general/standard)
+**Assessment:** N/A - No special domain compliance requirements
+
+**Note:** This PRD is for a developer tooling domain without regulatory compliance requirements.
+
+## Project-Type Compliance Validation
+
+**Project Type:** cli_tool
+
+### Required Sections
+
+**Command Structure:** Present — "Integration Contract" subsection defines `check_enrichment` API, "Rule Taxonomy" defines 10 commands/rule identifiers, FR42 covers `docvet enrichment` and `docvet check` CLI commands.
+
+**Output Formats:** Present — "Scripting & CI Support" subsection defines `file:line: rule message` output format plus summary line format.
+
+**Config Schema:** Present — "Config Schema Update" subsection documents all 11 toggles (10 booleans + `require-examples` list) with TOML example.
+
+**Scripting Support:** Present — "Scripting & CI Support" subsection covers exit codes (0/1), greppable output, composability.
+
+### Excluded Sections (Should Not Be Present)
+
+**Visual Design:** Absent ✓
+**UX Principles:** Absent ✓
+**Touch Interactions:** Absent ✓
+
+### Compliance Summary
+
+**Required Sections:** 4/4 present
+**Excluded Sections Present:** 0 (clean)
+**Compliance Score:** 100%
+
+**Severity:** Pass
+
+**Recommendation:** All required sections for cli_tool are present and adequately documented. No excluded sections found.
+
+## SMART Requirements Validation
+
+**Total Functional Requirements:** 42
+
+### Scoring Summary
+
+**All scores >= 3:** 100% (42/42)
+**All scores >= 4:** 90.5% (38/42)
+**Overall Average Score:** 4.73/5.0
+
+### Flagged FRs (scores of 3 in any category)
+
+**FR8** (S=3, M=3): "exports" in `__init__.py` context is undefined — does this mean `__all__`, public names, or both?
+
+**FR11** (S=3, M=3): "typed format" needs explicit pattern showing `name (type): description` as the expected match vs `name: description` as the violation.
+
+**FR12** (S=3, M=3, A=3, R=3): "cross-reference syntax" is used 4 times in the PRD but never formally defined. Weakest FR — no user journey demonstrates this rule.
+
+**FR38** (S=3, M=3): "gracefully handle malformed docstrings" — the specificity exists in NFR7 ("broken indentation, missing colons, non-standard headers") but is absent from the FR itself.
+
+### Overall Assessment
+
+**Severity:** Pass (< 10% flagged — 4/42 = 9.5%)
+
+**Recommendation:** FRs demonstrate strong SMART quality overall (4.73/5.0 average). The 4 flagged FRs share a pattern: domain concepts used but not formally defined in the requirement text. FR12 is the weakest (cross-reference syntax undefined). Fixes are straightforward: embed concrete definitions into the FR text so each is self-contained for test writing.
+
+## Holistic Quality Assessment
+
+### Document Flow & Coherence
+
+**Assessment:** Excellent
+
+**Strengths:**
+- Strong narrative arc from vision to requirements — natural funnel structure
+- Consistent terminology throughout (14-scenario/10-rule distinction reinforced without contradiction)
+- Precise internal cross-referencing (e.g., "See 'Project Scoping > MVP Feature Set'")
+- No contradictions found between sections or with the actual codebase
+
+**Areas for Improvement:**
+- "CLI Tool Specific Requirements" section title is slightly misleading — content is the enrichment module architecture (integration contract, rule taxonomy, config schema), not CLI flags/formatting
+- Minor redundancy between Success Criteria "Technical Success" and "Measurable Outcomes" subsections
+
+### Dual Audience Effectiveness
+
+**For Humans:**
+- Executive-friendly: Excellent — vision and positioning understood in under 2 minutes
+- Developer clarity: Excellent — integration contract is precise enough to code against immediately
+- Stakeholder decision-making: Good — phased development and risk mitigation are concrete (no timeline estimates, acceptable for solo developer project)
+
+**For LLMs:**
+- Machine-readable structure: Excellent — consistent heading hierarchy, numbered IDs, code blocks, tables
+- Architecture readiness: Excellent — function signature, dataclass definition, import paths, and constraints sufficient to generate module skeleton
+- Epic/Story readiness: Good — some FRs (FR32, FR33) pack multiple analyses into one requirement, requiring decomposition for story sizing
+
+**Dual Audience Score:** 5/5
+
+### BMAD PRD Principles Compliance
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| Information Density | Met | 0 violations confirmed |
+| Measurability | Met | 5 minor caveats across 61 requirements |
+| Traceability | Partial | 4/10 rules lack journey demonstration |
+| Domain Awareness | Met | Deep Python tooling ecosystem awareness |
+| Zero Anti-Patterns | Met | No filler, hedging, or vague language |
+| Dual Audience | Met | Works for executives, developers, and LLMs |
+| Markdown Format | Met | Proper hierarchy, tables, code blocks, YAML frontmatter |
+
+**Principles Met:** 6.5/7 (Traceability partial)
+
+### Overall Quality Rating
+
+**Rating:** 4.5/5 - Strong Good, approaching Excellent
+
+The PRD balances specificity without over-prescription, maintains tight scope control (missing-vs-incomplete boundary), and is grounded in the actual codebase state. What prevents a full 5: the traceability gap (4 rules undemonstrated in journeys), minor section redundancy, and slightly misleading section title.
+
+### Top 3 Improvements
+
+1. **Add a journey (or variant) exercising under-represented rules**
+   `missing-receives`, `missing-other-parameters`, `missing-cross-references`, and `prefer-fenced-code-blocks` have no journey coverage. A compact "edge case journey" would close the traceability loop. Highest-impact change.
+
+2. **Decompose composite FRs (FR32, FR33, FR35) into atomic requirements**
+   FR32 packs 5 analyses into one requirement; FR33 combines 4 class type detections. Splitting improves testability and LLM story-generation readiness.
+
+3. **Rename "CLI Tool Specific Requirements" to "Enrichment Module Specification"**
+   The section contains the integration contract, rule taxonomy, and config schema — not CLI flags. A more accurate title improves document navigability.
+
+### Summary
+
+**This PRD is:** A production-ready, high-quality requirements document that provides sufficient precision for immediate implementation while maintaining appropriate abstraction boundaries.
+
+**To make it great:** Close the traceability gap with an edge-case journey, decompose composite FRs for atomicity, and rename the CLI section for accuracy.
+
+## Completeness Validation
+
+### Template Completeness
+
+**Template Variables Found:** 0
+No `{variable}`, `{{variable}}`, `[placeholder]`, or `[TODO]` patterns found. One contextual `TBD` on line 380 ("Sequencing TBD based on early adopter feedback") is a deliberate product decision, not an unfilled template.
+
+### Content Completeness by Section
+
+| Section | Status |
+|---------|--------|
+| Executive Summary | Complete |
+| Success Criteria | Complete (4 subcategories, all measurable) |
+| Product Scope | Complete (in-scope, out-of-scope, competitive context) |
+| User Journeys | Complete (5 journeys, 5 personas, full narrative arcs) |
+| CLI Tool Specific Requirements | Complete (integration contract, rule taxonomy, config schema, scripting/CI, technical guidance) |
+| Project Scoping | Complete (MVP, 3-phase roadmap, prerequisite PRs, risk mitigation) |
+| Functional Requirements | Complete (FR1-FR42, 6 categories) |
+| Non-Functional Requirements | Complete (NFR1-NFR19, 5 categories) |
+
+### Section-Specific Completeness
+
+**Success Criteria Measurability:** All measurable — each criterion describes observable behavior or specific test artifacts
+**User Journeys Coverage:** Yes — all 5 target persona types (developer, senior dev, CI system, tech lead, new adopter)
+**FRs Cover MVP Scope:** Yes — all 10 rule identifiers and 14 detection scenarios mapped to FRs
+**NFRs Have Specific Criteria:** All — 19 NFRs each with verifiable metrics or criteria
+
+### Frontmatter Completeness
+
+**stepsCompleted:** Present (12 steps)
+**status:** Present (`complete`)
+**classification:** Present (projectType, domain, complexity, projectContext)
+**inputDocuments:** Present (15 entries)
+**documentCounts:** Present (minor discrepancy: 13 vs 15 actual entries)
+**workflowType:** Present
+**projectName:** Present
+**featureScope:** Present
+
+**Frontmatter Completeness:** 8/8 fields populated
+
+### Completeness Summary
+
+**Overall Completeness:** 100% (8/8 sections complete)
+
+**Critical Gaps:** 0
+**Minor Gaps:** 1 (frontmatter `documentCounts.projectDocs: 13` vs 15 `inputDocuments` entries — metadata discrepancy only)
+
+**Severity:** Pass
+
+**Recommendation:** PRD is complete with all required sections and content present. No template variables remaining. Ready for implementation.

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -1,0 +1,505 @@
+---
+stepsCompleted:
+  - 'step-01-init'
+  - 'step-02-discovery'
+  - 'step-03-success'
+  - 'step-04-journeys'
+  - 'step-05-domain-skipped'
+  - 'step-06-innovation-skipped'
+  - 'step-07-project-type'
+  - 'step-08-scoping'
+  - 'step-09-functional'
+  - 'step-10-nonfunctional'
+  - 'step-11-polish'
+  - 'step-12-complete'
+status: 'complete'
+classification:
+  projectType: 'cli_tool'
+  domain: 'developer_tooling'
+  complexity: 'medium'
+  projectContext: 'brownfield'
+inputDocuments:
+  - '_bmad-output/project-context.md'
+  - 'docs/product-vision.md'
+  - 'docs/architecture.md'
+  - 'docs/project-overview.md'
+  - 'docs/development-guide.md'
+  - 'docs/source-tree-analysis.md'
+  - 'docs/index.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-4-cli-scaffold.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-ci-workflow.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-config-reader.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-file-discovery.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-7-ast-helpers.md'
+  - '_bmad-output/implementation-artifacts/tech-spec-wire-discovery-cli.md'
+  - 'gh-issue-8'
+documentCounts:
+  briefs: 0
+  research: 0
+  brainstorming: 0
+  projectDocs: 14
+workflowType: 'prd'
+projectName: 'docvet'
+featureScope: 'enrichment-check'
+---
+
+# Product Requirements Document - docvet
+
+**Author:** Alberto-Codes
+**Date:** 2026-02-08
+
+## Executive Summary
+
+docvet is a Python CLI tool for comprehensive docstring quality vetting. This PRD defines requirements for the **enrichment check module** (Layer 3: completeness) — the first real check module in docvet's six-layer quality model.
+
+The enrichment check fills a 4-year ecosystem gap by detecting missing docstring sections (Raises, Yields, Attributes, Examples, and more) through AST analysis. It complements ruff (style) and interrogate (presence) rather than competing with them. darglint — the only prior tool in this space — has been unmaintained since 2022; ruff stops at D417 (param completeness).
+
+**Target users:** Python developers writing Google-style docstrings, teams using mkdocs-material + mkdocstrings.
+
+**Scope:** 10 rule identifiers covering 14 detection scenarios, `required` vs `recommended` categorization, full config customization via `[tool.docvet.enrichment]` in pyproject.toml.
+
+### Key Terms
+
+- **Detection scenario**: A specific code pattern that triggers a check (e.g., "function with `raise` but no `Raises:` section"). 14 total.
+- **Rule identifier**: A stable kebab-case name emitted in findings (e.g., `missing-raises`). 10 total — multiple scenarios can share one rule ID.
+- **Required vs recommended**: Category baked into each rule definition. Required = misleading omission; recommended = improvement opportunity.
+- **Missing vs incomplete**: MVP detects *missing* sections only (no `Raises:` section at all). *Incomplete* sections (has `Raises:` but doesn't list all exceptions) are a Growth feature.
+
+## Success Criteria
+
+### User Success
+
+- A developer runs `docvet enrichment` and gets a clear, prioritized list of missing docstring sections across their codebase
+- Each finding is immediately actionable: file, line, symbol name, a human-readable kebab-case rule identifier (e.g., `missing-raises`), and a concise message explaining what's missing and why
+- Findings are categorized as `required` (misleading omission) or `recommended` (improvement opportunity), so developers can triage effectively
+- Well-documented code produces zero findings -- no false positives on complete docstrings
+- The check respects existing `EnrichmentConfig` toggles, so teams customize which rules run without noise
+
+### Business Success
+
+- Fills the explicit gap between ruff D417 (param completeness) and full section completeness -- no existing tool covers this
+- Positions docvet as a credible addition to the Python quality toolchain alongside ruff, ty, and interrogate
+- Rule identifiers follow industry convention (ty-style kebab-case), making docvet feel native to modern Python workflows
+- All 14 detection scenarios (10 rule identifiers) ship together, delivering complete Layer 3 coverage in a single release
+
+### Technical Success
+
+- `check_enrichment(source, tree, config, file_path)` returns `list[Finding]` with zero side effects -- pure function, deterministic output
+- Each `Finding` carries: `file`, `line`, `symbol`, `rule` (kebab-case stable identifier), `message`, `category` (`required` | `recommended`)
+- All 14 detection scenarios (mapping to 10 distinct rule identifiers) implemented and individually toggleable via `EnrichmentConfig`
+- No new runtime dependencies -- stdlib `ast` + existing `ast_utils.Symbol` infrastructure
+- Checks are isolated -- no imports from other check modules, no shared mutable state
+- Quality gates pass: ruff, ty, pytest with >=85% coverage, interrogate
+
+### Measurable Outcomes
+
+- `tests/fixtures/missing_raises.py` produces exactly the expected `missing-raises` finding
+- `tests/fixtures/missing_yields.py` produces exactly the expected `missing-yields` finding
+- `tests/fixtures/complete_module.py` produces zero findings
+- Each of the 10 rule identifiers has at least one dedicated unit test with a source string fixture
+- `EnrichmentConfig` toggles (`require-raises = false`, etc.) suppress the corresponding rule's findings
+
+## Product Scope
+
+### Competitive Context
+
+darglint -- the only tool that partially addressed Args/Returns/Raises alignment -- has been unmaintained since 2022. Ruff's D rules stop at D417 (param completeness) and explicitly chose not to go deeper into section completeness. This leaves a 4-year vacuum in the ecosystem for docstring completeness checking. docvet fills this gap by complementing ruff (style) and interrogate (presence) rather than competing with them -- the six-layer quality model makes the composability explicit: layers 1-2 are delegated to existing tools, layers 3-6 are docvet's territory.
+
+### MVP - Minimum Viable Product
+
+The MVP delivers all 10 rule identifiers (14 detection scenarios), the shared `Finding` type, full `EnrichmentConfig` integration, and comprehensive unit tests. See "Project Scoping & Phased Development > MVP Feature Set" for the authoritative implementation checklist.
+
+### Growth & Vision
+
+Growth features include inline suppression, JSON output, and incomplete section detection. Vision includes editor/LSP integration and additional docstring style support. See "Project Scoping & Phased Development > Post-MVP Features" for the full Phase 2 and Phase 3 roadmap.
+
+## User Journeys
+
+### Journey 1: Dev During Development -- "The Missing Raises Catch"
+
+**Persona:** Maya, a mid-level Python developer working on a data pipeline library. She writes Google-style docstrings diligently but sometimes forgets edge cases.
+
+**Opening Scene:** Maya just finished implementing a new `parse_config()` function. It validates input and raises `ValueError` on bad keys and `FileNotFoundError` when the config path is missing. She wrote a clean docstring with `Args:` and `Returns:` sections but didn't add a `Raises:` section -- she was focused on the happy path.
+
+**Rising Action:** Before committing, she runs `docvet enrichment` on her working directory. The terminal shows:
+
+```
+src/pipeline/config.py:42: missing-raises Function 'parse_config' raises ValueError, FileNotFoundError but has no Raises: section
+```
+
+One finding. Clear file, line, symbol, rule name, and a message that tells her exactly which exceptions she missed.
+
+**Climax:** Maya opens the file, adds the `Raises:` section documenting both exceptions with descriptions. She runs `docvet enrichment` again -- zero findings. She knows her docstring now accurately describes the function's behavior.
+
+**Resolution:** The downstream developer who calls `parse_config()` next week sees the `Raises:` section in their IDE tooltip and adds proper error handling. Maya's docstring prevented a silent failure in production.
+
+### Journey 2: PR Workflow -- "The Pre-Commit Safety Net"
+
+**Persona:** Raj, a senior developer on a team that runs `docvet check --staged` before every commit.
+
+**Opening Scene:** Raj refactored a data validation class, converting it from a plain class to a `dataclass` with 6 fields. He updated the class docstring's summary line but didn't add an `Attributes:` section for the new fields.
+
+**Rising Action:** He stages his changes and runs `docvet check --staged`. The enrichment check fires alongside freshness, coverage, and griffe:
+
+```
+src/models/validation.py:15: missing-attributes Dataclass 'ValidationResult' has 6 fields but no Attributes: section
+```
+
+The other three checks pass clean. Just this one enrichment finding.
+
+**Climax:** Raj adds the `Attributes:` section with types and descriptions for all 6 fields. He re-stages and runs `docvet check --staged` again -- all clear. He commits with confidence.
+
+**Resolution:** During PR review, the reviewer sees the complete `Attributes:` section and understands the dataclass instantly. No review comment asking "what does `threshold` do?" -- the docstring already answers it.
+
+**Edge Case -- The Disagreement:** A week later, Raj gets a `missing-examples` finding on a private helper function `_normalize_path()`. He doesn't think a private utility needs an `Examples:` section. He adjusts `require-examples = ["class", "protocol", "dataclass"]` in `pyproject.toml`, removing the recommendation for plain functions. Next run, the finding is gone. The tool respects his judgment -- it's a guardrail, not a mandate.
+
+### Journey 3: CI Pipeline -- "The Automated Gate"
+
+**Persona:** The CI system running on a GitHub Actions PR workflow for a team using docvet with default configuration.
+
+**Opening Scene:** A junior developer opens a PR that adds a generator function with `yield` statements but no `Yields:` section in the docstring. The PR triggers the CI pipeline.
+
+**Rising Action:** The CI job runs `docvet check`. With default config, `enrichment` is in `warn-on` -- advisory mode. The enrichment check produces:
+
+```
+src/stream/processor.py:88: missing-yields Generator 'stream_events' uses yield but has no Yields: section
+```
+
+Docvet exits with code 0. The CI check passes green, but the finding appears in the build log as a warning.
+
+**Climax:** The tech lead notices the warning in the PR log during review. She asks the developer to fix it. After three similar PRs in a row, she decides the team is ready for enforcement. She moves `enrichment` to `fail-on` in `pyproject.toml`:
+
+```toml
+[tool.docvet]
+fail-on = ["enrichment"]
+```
+
+Now enrichment findings cause non-zero exit. CI goes red on incomplete docstrings.
+
+**Resolution:** The next PR with a missing `Yields:` section fails CI automatically. The developer sees the failed check, reads the clear message, and fixes it before review. The team's documentation standard is enforced without human reviewers spending time on it. The gradual promotion from `warn-on` to `fail-on` let the team adopt at their own pace.
+
+### Journey 4: Tech Lead Audit -- "The Codebase Sweep"
+
+**Persona:** Carlos, a tech lead adopting docvet for his team's mkdocs-material documentation site. He wants to understand the documentation debt across the codebase.
+
+**Opening Scene:** Carlos configures `[tool.docvet.enrichment]` in `pyproject.toml`, keeping all defaults (`require-raises = true`, `require-yields = true`, etc.) but setting `require-examples` to only `["protocol", "dataclass"]` -- his team doesn't need examples on every public function yet.
+
+**Rising Action:** He runs `docvet enrichment --all`. The terminal shows 47 findings across 12 files. He sees a mix of `required` and `recommended` categories:
+
+```
+src/core/engine.py:23: missing-raises ...
+src/core/engine.py:91: missing-warns ...
+src/models/schema.py:15: missing-attributes ...
+src/models/schema.py:44: missing-typed-attributes ...
+src/protocols/handler.py:8: missing-examples ...
+```
+
+**Climax:** Carlos triages by rule. He creates a team issue for the 12 `missing-raises` findings (highest impact -- actively misleading callers). He deprioritizes the 5 `missing-examples` findings on protocols as a future sprint item. The kebab-case rule identifiers make it easy to grep, filter, and assign.
+
+**Resolution:** Over two sprints, the team systematically works through the findings. Each sprint they re-run `docvet enrichment --all` and watch the count drop. Carlos eventually moves `enrichment` to `fail-on` to prevent new debt from accumulating.
+
+### Journey 5: New Adopter -- "The First Run"
+
+**Persona:** Priya, a developer who just heard about docvet and wants to try it on her existing Django REST framework project with ~200 Python files.
+
+**Opening Scene:** Priya installs docvet (`pip install docvet`) and runs `docvet enrichment --all` with zero configuration. Default `EnrichmentConfig` applies -- all rules enabled.
+
+**Rising Action:** The output is overwhelming: 183 findings scroll past. Every function that raises an exception, every generator, every class missing `Attributes:`. Priya's stomach drops -- "Is my code really this bad?"
+
+**Climax:** But then she sees the summary at the bottom:
+
+```
+183 findings (34 required, 149 recommended)
+```
+
+That single line changes everything. 34 real issues where her docstrings actively mislead developers. 149 nice-to-haves that would make the docs better but aren't urgent. She's not drowning -- she has a clear path forward.
+
+She adds targeted configuration to focus on what matters first:
+
+```toml
+[tool.docvet.enrichment]
+require-warns = false
+require-other-parameters = false
+require-cross-references = false
+prefer-fenced-code-blocks = false
+require-examples = []
+```
+
+She re-runs: 34 findings. All `required` -- missing `Raises:`, `Yields:`, and `Attributes:` sections. Manageable.
+
+**Resolution:** Priya fixes the 8 most critical findings in her core modules, commits, and sets up docvet in CI with `enrichment` in `warn-on`. She'll tighten the config as the team catches up. The tool met her where she was instead of demanding perfection on day one.
+
+### Journey Requirements Traceability
+
+All journey-revealed capabilities are formally captured in the Functional Requirements section below. CLI/reporting layer dependencies (output formatting, summary line, exit codes, discovery modes) are out of enrichment module scope but required for full journey completion in the same release.
+
+## Enrichment Module Specification
+
+### Project-Type Overview
+
+docvet is a non-interactive, scriptable CLI tool in the tradition of ruff, ty, and interrogate. The enrichment check (`check_enrichment`) is a pure function that produces a flat list of `Finding` objects -- it has no awareness of the CLI layer, output formatting, or exit codes. The CLI layer is the consumer: it calls the check, formats findings for terminal output, and maps `fail-on` / `warn-on` configuration to exit codes.
+
+### Integration Contract
+
+**Public API:**
+
+```python
+def check_enrichment(
+    source: str,
+    tree: ast.Module,
+    config: EnrichmentConfig,
+    file_path: str,
+) -> list[Finding]:
+```
+
+- **Pure function**: no I/O, no side effects, deterministic output
+- **Caller provides AST**: the function does not call `ast.parse()` -- the caller handles `SyntaxError`
+- **`file_path` enables context-aware detection**: needed for `__init__.py` module rules and for populating `Finding.file` -- the function owns full `Finding` construction
+- **Config toggles respected**: disabled rules produce zero findings, period
+- **Returns empty list on clean code**: not `None`, not a sentinel
+- **One finding per symbol per rule**: if multiple detection branches match the same symbol for the same rule (e.g., a `@dataclass` that also has `__init__` self-assignments), only one `missing-attributes` finding is emitted
+
+**`Finding` dataclass (lives in `src/docvet/checks/__init__.py`):**
+
+```python
+@dataclass(frozen=True)
+class Finding:
+    file: str
+    line: int
+    symbol: str
+    rule: str        # kebab-case stable identifier
+    message: str
+    category: Literal["required", "recommended"]
+```
+
+**Import contract:**
+
+- `checks/__init__.py` exports `Finding` only -- it is a shared types module, not a barrel file
+- Each check module exports its own public function: `checks.enrichment.check_enrichment`, `checks.freshness.check_freshness`, etc.
+- The CLI imports `Finding` from `docvet.checks` and `check_enrichment` from `docvet.checks.enrichment` independently
+- No cross-imports between check modules -- each check depends only on `checks.Finding` and `ast_utils`
+
+### Rule Taxonomy
+
+The vision doc lists 14 detection scenarios. After consolidation, these map to **10 distinct rule identifiers**. The difference: multiple scenarios can emit the same rule ID when they detect the same kind of omission in different contexts.
+
+| Rule Identifier | Category | Config Toggle | Detection Scenarios |
+|----------------|----------|---------------|-------------------|
+| `missing-raises` | required | `require-raises` | Functions/methods with `raise` statements lacking `Raises:` section |
+| `missing-yields` | required | `require-yields` | Generator functions with `yield` lacking `Yields:` section |
+| `missing-receives` | required | `require-receives` | Generators using `value = yield` lacking `Receives:` section |
+| `missing-warns` | required | `require-warns` | Functions calling `warnings.warn()` lacking `Warns:` section |
+| `missing-other-parameters` | recommended | `require-other-parameters` | Functions with `**kwargs` lacking `Other Parameters:` section |
+| `missing-attributes` | required | `require-attributes` | Classes with `__init__` self-assignments, dataclasses, NamedTuples, TypedDicts, `__init__.py` modules -- all lacking `Attributes:` section |
+| `missing-typed-attributes` | recommended | `require-typed-attributes` | `Attributes:` sections without `name (type): desc` format |
+| `missing-examples` | recommended | `require-examples` (list) | Public symbols in the `require-examples` list (class, protocol, dataclass, enum) lacking `Examples:` section; `__init__.py` modules lacking `Examples:` |
+| `missing-cross-references` | recommended | `require-cross-references` | `See Also:` sections without cross-reference syntax; `__init__.py` modules lacking `See Also:` section |
+| `prefer-fenced-code-blocks` | recommended | `prefer-fenced-code-blocks` | `Examples:` sections using `>>>` doctest format instead of fenced code blocks |
+
+**Key consolidations:**
+
+- **`missing-attributes` covers all class-like constructs**: plain classes (via `__init__` self-assignments), dataclasses, NamedTuples, TypedDicts, and `__init__.py` module-level exports. One rule, one identifier, one toggle -- the detection logic branches internally by construct type. This is the most complex rule with 5 detection branches, but the output is always one finding per symbol.
+- **`__init__.py` module rules are not separate rules**: they are existing rules (`missing-attributes`, `missing-examples`, `missing-cross-references`) applied to module-level symbols. No new rule identifiers needed.
+- **`missing-examples` is controlled by a list, not a boolean**: `require-examples = ["class", "protocol", "dataclass", "enum"]` specifies which symbol types trigger the rule. Empty list disables it entirely.
+
+### Config Schema Update
+
+The existing `EnrichmentConfig` has 9 boolean toggles + 1 list. The rule taxonomy reveals one config gap:
+
+**New toggle needed:** `require-attributes: bool = True`
+
+This controls the `missing-attributes` rule. Without it, there's no way to disable Attributes checking for teams that don't document class fields in docstrings (preferring type annotations alone). Since `missing-attributes` is a `required` category rule, the toggle defaults to `True`. This is a backward-compatible addition -- new field with a default value, no existing code breaks.
+
+**Updated `EnrichmentConfig` (10 booleans + 1 list):**
+
+```toml
+[tool.docvet.enrichment]
+require-raises = true              # missing-raises
+require-yields = true              # missing-yields
+require-receives = true            # missing-receives
+require-warns = true               # missing-warns
+require-other-parameters = true    # missing-other-parameters
+require-attributes = true          # missing-attributes (NEW)
+require-typed-attributes = true    # missing-typed-attributes
+require-cross-references = true    # missing-cross-references
+prefer-fenced-code-blocks = true   # prefer-fenced-code-blocks
+require-examples = ["class", "protocol", "dataclass", "enum"]  # missing-examples
+```
+
+Every rule now has a corresponding toggle. No always-on rules -- every team can customize to their needs.
+
+### Scripting & CI Support
+
+- **Exit codes**: `0` = no findings (or all findings in `warn-on` checks), `1` = findings in `fail-on` checks. Controlled by top-level `fail-on` / `warn-on` lists, not by individual rules.
+- **Output format**: `file:line: rule message` (one finding per line) -- greppable, parseable, familiar to ruff/ty users.
+- **Summary line**: `N findings (X required, Y recommended)` -- printed after all findings when count > 0. Part of the CLI/reporting layer, not the enrichment module.
+- **Composability**: `docvet enrichment` runs only the enrichment check. `docvet check` runs all enabled checks. Each check produces `list[Finding]` independently -- no shared state between checks.
+
+### Technical Guidance for Implementation
+
+- **Section detection**: Google-style docstring section headers (`Args:`, `Returns:`, `Raises:`, etc.) detected via regex/string matching on the raw docstring text. No third-party parser needed.
+- **AST infrastructure**: Reuses existing `ast_utils.Symbol` dataclass for symbol extraction. `Symbol.kind` distinguishes functions, classes, methods, and modules. `Symbol.docstring` provides the raw docstring text for section analysis.
+- **`__init__.py` detection**: `file_path` parameter enables checking `file_path.endswith("__init__.py")`. When true, apply module-specific rules (`missing-attributes` for exports, `missing-examples`, `missing-cross-references`) to the module-level symbol.
+- **Dataclass/NamedTuple/TypedDict detection**: AST decorator inspection for `@dataclass`, base class inspection for `NamedTuple`/`TypedDict`. These are well-defined AST patterns.
+- **Deduplication**: `missing-attributes` detection branches (plain class, dataclass, NamedTuple, TypedDict, module) are checked in priority order. First match emits the finding; subsequent branches for the same symbol are skipped.
+- **No new runtime dependencies**: stdlib `ast` + existing `ast_utils` + `re` for section header matching.
+
+## Project Scoping & Phased Development
+
+### MVP Strategy & Philosophy
+
+**MVP Approach:** Problem-solving MVP -- deliver the specific capability that fills the 4-year ecosystem gap in docstring section completeness checking. The scaffolding (CLI, config, discovery, AST helpers) is already implemented; this MVP adds the first real check module.
+
+**Scope boundary — missing vs incomplete:** MVP rules detect **missing sections only**. A function that raises `ValueError` and `TypeError` but has no `Raises:` section at all triggers `missing-raises`. A function that has a `Raises:` section documenting `ValueError` but not `TypeError` does **not** trigger a finding -- that's an *incomplete* section, which is a Growth feature (analogous to how ruff D417 checks param completeness but docvet Layer 3 checks section presence). This boundary keeps detection logic simple and false-positive risk low.
+
+### MVP Feature Set (Phase 1)
+
+**Core User Journeys Enabled:** All five journeys. The enrichment module is the single deliverable that enables all journeys. Note: Journey 3 (CI exit codes) and Journey 5 (summary line) also depend on CLI/reporting layer behavior that exists as stubs -- full journey completion requires wiring those stubs, which is out of enrichment module scope but in the same release scope.
+
+**Prerequisite Deliverables (ship before main enrichment PR):**
+
+1. **Config update PR:** Add `require-attributes: bool = True` to `EnrichmentConfig`, update `_VALID_ENRICHMENT_KEYS`, update `_parse_enrichment` validation, update affected tests. Small, isolated change.
+2. **`checks` package PR:** Create `src/docvet/checks/__init__.py` with `Finding` dataclass. Establishes the shared type contract for all future checks. `Finding` is a frozen API -- its 6-field shape (`file`, `line`, `symbol`, `rule`, `message`, `category`) must remain stable across checks.
+
+**Main Deliverable:**
+
+- `check_enrichment(source, tree, config, file_path) -> list[Finding]` pure function in `checks/enrichment.py`
+- All 10 rule identifiers covering 14 detection scenarios (missing section detection only, not incomplete section detection)
+- Full respect for all 11 config toggles (10 booleans + `require-examples` list)
+- Google-style section header detection for: `Raises:`, `Yields:`, `Receives:`, `Warns:`, `Other Parameters:`, `Attributes:`, `Examples:`, `See Also:` (8 headers detected; `Args:` and `Returns:` recognized but not checked for absence -- that's ruff's territory)
+- One finding per symbol per rule (deduplication guarantee)
+- Zero findings on complete, well-documented code
+- Comprehensive unit tests using source string fixtures (≥85% project-wide coverage; aim for ≥90% on `checks/enrichment.py` specifically)
+- Tests against existing fixture files (`missing_raises.py`, `missing_yields.py`, `complete_module.py`)
+- CLI wiring via existing `_run_enrichment` stub in `cli.py`
+
+### Post-MVP Features
+
+**Phase 2 (Growth):**
+
+Sequencing TBD based on early adopter feedback. Candidates:
+
+- Inline suppression: `# docvet: ignore[missing-raises]`
+- JSON output format for CI integration pipelines
+- Incomplete section detection (e.g., `Raises:` section exists but doesn't cover all raised exceptions)
+- `--fix` suggestions (auto-insert empty section skeletons)
+- Rule documentation URLs in findings (ruff pattern)
+- Per-rule severity override in config
+- SARIF output format
+
+**Phase 3 (Vision):**
+
+- Editor/LSP integration for real-time feedback
+- GitHub Actions annotation format for PR inline comments
+- Cross-check intelligence (enrichment + freshness combined findings)
+- Numpy/Sphinx docstring style support
+
+### Risk Mitigation Strategy
+
+**Technical Risks:**
+
+- `missing-attributes` has 5 detection branches with deduplication -- mitigated by implementing and testing each branch independently before composition
+- Section header regex accuracy -- mitigated by starting with strict matching (exact names, correct indentation) and relaxing based on user feedback
+- `Finding` is a frozen API consumed by all future checks -- mitigated by shipping it as a prerequisite PR with deliberate review before enrichment logic builds on it
+
+**Market Risks:** Minimal -- verified ecosystem gap (darglint unmaintained since 2022, ruff stops at D417). No competing tool covers this space.
+
+**Resource Risks:** Solo developer, but module is self-contained with no external dependencies. Scaffolding already built. Three-PR sequencing (config → Finding → enrichment) keeps each PR reviewable and CI-friendly. Risk is timeline, not feasibility.
+
+## Functional Requirements
+
+### Section Detection
+
+- **FR1:** The system can detect functions and methods that contain `raise` statements but lack a `Raises:` section in their docstring
+- **FR2:** The system can detect generator functions that contain `yield` expressions but lack a `Yields:` section in their docstring
+- **FR3:** The system can detect generators that use the `value = yield` send pattern but lack a `Receives:` section in their docstring
+- **FR4:** The system can detect functions that call `warnings.warn()` but lack a `Warns:` section in their docstring
+- **FR5:** The system can detect functions with `**kwargs` parameters but lack an `Other Parameters:` section in their docstring
+- **FR6:** The system can detect classes with `__init__` self-assignments that lack an `Attributes:` section in their docstring
+- **FR7:** The system can detect dataclasses, NamedTuples, and TypedDicts with fields that lack an `Attributes:` section in their docstring
+- **FR8:** The system can detect `__init__.py` modules that lack an `Attributes:` section documenting their exports
+- **FR9:** The system can detect public symbols (configurable by type) that lack an `Examples:` section in their docstring
+- **FR10:** The system can detect `__init__.py` modules that lack an `Examples:` section in their docstring
+- **FR11:** The system can detect `Attributes:` sections that lack typed format (`name (type): description`)
+- **FR12:** The system can detect `See Also:` sections that lack cross-reference syntax
+- **FR13:** The system can detect `__init__.py` modules that lack a `See Also:` section in their docstring
+- **FR14:** The system can detect `Examples:` sections that use `>>>` doctest format instead of fenced code blocks
+- **FR15:** The system can recognize `Args:` and `Returns:` section headers for docstring parsing context without checking for their absence
+
+### Finding Production
+
+- **FR16:** The system can produce a structured finding for each detected issue, carrying file path, line number, symbol name, rule identifier, human-readable message, and category
+- **FR17:** The system can categorize each finding as `required` (misleading omission) or `recommended` (improvement opportunity) based on the rule definition
+- **FR18:** The system can produce at most one finding per symbol per rule, even when multiple detection branches match the same symbol
+- **FR19:** The system can produce zero findings when analyzing well-documented code with complete docstrings
+- **FR20:** The system can produce zero findings for symbols that have no docstring
+- **FR21:** The system can produce findings only for missing sections, not for sections that exist but are incomplete
+- **FR22:** The system can provide Finding as an immutable (frozen) dataclass that cannot be modified after creation
+
+### Rule Management
+
+- **FR23:** The system can identify each finding with a stable, human-readable kebab-case rule identifier (e.g., `missing-raises`, `missing-yields`)
+- **FR24:** A developer can reference rule identifiers in configuration, output filtering, and issue tracking
+- **FR25:** The system can map 14 detection scenarios to 10 distinct rule identifiers, applying the same rule ID across related detection contexts
+
+### Configuration
+
+- **FR26:** A developer can enable or disable each of the 10 rules independently via boolean toggles in `[tool.docvet.enrichment]`
+- **FR27:** A developer can configure which symbol types trigger the `missing-examples` rule via a list of type names (class, protocol, dataclass, enum)
+- **FR28:** The system can validate `require-examples` entries against known symbol types, rejecting unrecognized entries at config load time
+- **FR29:** A developer can disable all enrichment findings by setting `require-examples = []` and all boolean toggles to `false`
+- **FR30:** The system can apply defaults (all rules enabled, `require-examples = ["class", "protocol", "dataclass", "enum"]`) when no enrichment configuration is provided
+- **FR31:** The system can recognize 8 Google-style section headers (`Raises:`, `Yields:`, `Receives:`, `Warns:`, `Other Parameters:`, `Attributes:`, `Examples:`, `See Also:`) for missing section detection
+
+### Symbol Analysis
+
+- **FR32:** The system can analyze function and method symbols for raise statements, yield expressions, send patterns, warnings calls, and kwargs parameters
+- **FR33:** The system can analyze class symbols to determine construct type (plain class with `__init__`, dataclass, NamedTuple, TypedDict)
+- **FR34:** The system can analyze module symbols to determine if the source file is an `__init__.py`
+- **FR35:** The system can extract and parse raw docstring text from symbols to identify which sections are present
+- **FR36:** The system can analyze any symbol with a non-empty docstring, regardless of docstring length or section count
+- **FR37:** The system can distinguish between symbols that have a docstring (analyze for completeness) and symbols with no docstring (skip -- presence checking is interrogate's job)
+- **FR38:** The system can process docstrings with broken indentation, missing section-header colons, or non-standard header names without raising exceptions, producing zero findings for symbols whose docstrings cannot be reliably parsed
+
+### Integration
+
+- **FR39:** The system can accept source code, a parsed AST, configuration, and file path as inputs and return a list of findings as output
+- **FR40:** The system can operate as a pure function with no I/O, no side effects, and deterministic output
+- **FR41:** The system can provide `Finding` as a shared type importable by all check modules without cross-check dependencies
+- **FR42:** A developer can run the enrichment check standalone via `docvet enrichment` or as part of all checks via `docvet check`
+
+## Non-Functional Requirements
+
+### Performance
+
+- **NFR1:** The enrichment check can analyze a single file (≤1000 lines) in under 50ms -- aspirational benchmark validated during implementation, not a CI-enforced gate
+- **NFR2:** The enrichment check can process a 200-file codebase via `docvet enrichment --all` in under 5 seconds on commodity hardware -- aspirational benchmark; the real gate is "fast enough for pre-commit hooks and CI pipelines without noticeable delay"
+- **NFR3:** The enrichment check adds no measurable overhead beyond AST parsing
+- **NFR4:** Memory usage scales linearly with file count, not quadratically -- each file is processed independently with no cross-file state (design invariant, not tested explicitly)
+
+### Correctness
+
+- **NFR5:** The enrichment check produces zero false positives on well-documented code with complete docstrings (deterministic, reproducible)
+- **NFR6:** The enrichment check produces identical output for identical input regardless of execution environment, time, or ordering
+- **NFR7:** Malformed docstrings (broken indentation, missing colons, non-standard headers) result in zero findings for that symbol, never a crash or traceback
+- **NFR8:** The enrichment check never modifies input data -- `source`, `tree`, and `config` remain unchanged after execution
+- **NFR9:** Finding messages are actionable -- each message names the specific symbol, the specific issue, and what section is missing, enabling the developer to fix the problem without additional context
+
+### Maintainability
+
+- **NFR10:** Each of the 10 rules can be understood, modified, and tested independently without knowledge of other rules
+- **NFR11:** Adding a new detection rule requires changes to at most 3 files: the rule implementation (`enrichment.py`), its config toggle (`config.py`), and its tests (`test_enrichment.py`)
+- **NFR12:** Test coverage on `checks/enrichment.py` targets ≥90% (aspirational, not CI-enforced), with project-wide coverage maintaining the ≥85% CI gate
+- **NFR13:** All quality gates pass: ruff check, ruff format, ty check, pytest, interrogate (95% docstring coverage)
+
+### Compatibility
+
+- **NFR14:** The enrichment check works on Python 3.12 and 3.13 (CI tests both versions)
+- **NFR15:** The enrichment check works on Linux, macOS, and Windows without platform-specific code paths
+- **NFR16:** No new runtime dependencies -- stdlib `ast`, `re`, and existing `ast_utils` only
+
+### Integration
+
+- **NFR17:** `Finding`'s 6-field shape (`file`, `line`, `symbol`, `rule`, `message`, `category`) is stable for v1 -- no fields are added, removed, or renamed within the v1 lifecycle
+- **NFR18:** The enrichment check integrates with the existing CLI dispatch pattern (`_run_enrichment` stub) without requiring changes to CLI argument parsing or global option handling
+- **NFR19:** Config additions (`require-attributes` toggle) are backward-compatible -- existing `pyproject.toml` files without this key continue to work with the default value

--- a/src/docvet/config.py
+++ b/src/docvet/config.py
@@ -35,6 +35,7 @@ class EnrichmentConfig:
     require_typed_attributes: bool = True
     require_cross_references: bool = True
     prefer_fenced_code_blocks: bool = True
+    require_attributes: bool = True
 
 
 @dataclass(frozen=True)
@@ -78,15 +79,16 @@ _VALID_FRESHNESS_KEYS: frozenset[str] = frozenset({"drift-threshold", "age-thres
 
 _VALID_ENRICHMENT_KEYS: frozenset[str] = frozenset(
     {
-        "require-examples",
-        "require-raises",
-        "require-yields",
-        "require-warns",
-        "require-receives",
-        "require-other-parameters",
-        "require-typed-attributes",
-        "require-cross-references",
         "prefer-fenced-code-blocks",
+        "require-attributes",
+        "require-cross-references",
+        "require-examples",
+        "require-other-parameters",
+        "require-raises",
+        "require-receives",
+        "require-typed-attributes",
+        "require-warns",
+        "require-yields",
     }
 )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -91,6 +91,11 @@ def test_enrichment_defaults_prefer_fenced_code_blocks_is_true():
     assert cfg.prefer_fenced_code_blocks is True
 
 
+def test_enrichment_defaults_require_attributes_is_true():
+    cfg = EnrichmentConfig()
+    assert cfg.require_attributes is True
+
+
 def test_docvet_defaults_src_root_is_dot():
     cfg = DocvetConfig()
     assert cfg.src_root == "."
@@ -254,6 +259,7 @@ age-threshold = 45
 
 [tool.docvet.enrichment]
 require-raises = false
+require-attributes = false
 require-examples = ["class"]
 """
     )
@@ -266,6 +272,7 @@ require-examples = ["class"]
     assert cfg.freshness.drift_threshold == 10
     assert cfg.freshness.age_threshold == 45
     assert cfg.enrichment.require_raises is False
+    assert cfg.enrichment.require_attributes is False
     assert cfg.enrichment.require_examples == ["class"]
 
 
@@ -335,6 +342,35 @@ require-yields = false
     assert cfg.enrichment.require_raises is False
     assert cfg.enrichment.require_yields is False
     assert cfg.enrichment.require_warns is True
+
+
+def test_load_config_nested_enrichment_require_attributes_false(
+    tmp_path, monkeypatch, write_pyproject
+):
+    monkeypatch.chdir(tmp_path)
+    write_pyproject(
+        """\
+[tool.docvet.enrichment]
+require-attributes = false
+"""
+    )
+    cfg = load_config()
+    assert cfg.enrichment.require_attributes is False
+
+
+def test_load_config_nested_enrichment_without_require_attributes_uses_default(
+    tmp_path, monkeypatch, write_pyproject
+):
+    monkeypatch.chdir(tmp_path)
+    write_pyproject(
+        """\
+[tool.docvet.enrichment]
+require-raises = false
+"""
+    )
+    cfg = load_config()
+    assert cfg.enrichment.require_attributes is True
+    assert cfg.enrichment.require_raises is False
 
 
 def test_load_config_explicit_path_uses_that_file(tmp_path):


### PR DESCRIPTION
The enrichment check module needs a `require-attributes` toggle so teams can independently enable or disable Attributes section checking for classes. Previously, `EnrichmentConfig` had no way to control this rule. This is the first prerequisite PR for the enrichment epic, adding the config foundation that later stories build on.

- Add `require_attributes: bool = True` field to `EnrichmentConfig` frozen dataclass
- Register `require-attributes` in `_VALID_ENRICHMENT_KEYS` (sorted alphabetically)
- Add 3 unit tests: default true, explicit false, backward compatibility
- Update `test_load_config_full_config_populates_all_fields` to cover the new field

Test: `uv run pytest tests/unit/test_config.py -v`

docs(enrichment): add planning artifacts for enrichment check module

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Minimal source change — 1 new dataclass field, 1 new key in a frozenset, 3+1 test updates. No parser logic changes needed since `_parse_enrichment` already handles boolean keys generically. Backward compatible (default `True`, frozen dataclass with default value).

### Related
- Part of #8
- Story: `_bmad-output/implementation-artifacts/1-1-add-require-attributes-config-toggle.md`
- Epic 1: Function-Level Enrichment Detection