### PR TITLE
fix(ci): add target-branch to release-please config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,5 +19,6 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Release-please-action@v4 defaults target-branch to the repo's default branch (develop), causing release PRs to target the wrong branch. This adds explicit `target-branch: main`.

- Add `target-branch: main` to release-please action configuration

Test: Re-run release-please after merge — PR should target main

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
One-line fix to release-please workflow.

### Related
Closes incorrect PR #84