### PR TITLE
ci(release): use PAT for release-please to trigger publish workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Why

GitHub's anti-cascade protection prevents workflows triggered by `GITHUB_TOKEN` from firing downstream workflows. This caused v1.0.1's `release: [published]` event to not trigger `publish.yml`, leaving PyPI stuck on v1.0.0.

## What changed

- Use `RELEASE_PLEASE_TOKEN` PAT (with `GITHUB_TOKEN` fallback) in `release-please.yml` so releases trigger the publish workflow
- Deleted the v1.0.1 release and tag so release-please can re-create it with the PAT

Test: CI only — release-please will validate on next push to main

---

## PR Review

### Checklist

- [x] PR title follows conventional commits
- [x] Changes match the PR description
- [x] No unrelated changes included

### Review Focus

- `release-please.yml` token configuration

### Related

- Same pattern used in gepa-adk's release-please workflow