### PR TITLE
fix(ci): rename action for marketplace publishing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'docvet'
+name: 'Docvet Check'
 description: 'Comprehensive docstring quality checks — completeness, freshness, rendering, and coverage for Python projects'
 branding:
   icon: 'shield'


### PR DESCRIPTION
GitHub Marketplace requires action names to not conflict with existing users or organizations. A dormant GitHub user `docvet` (created 2023-07-05, zero repos, zero activity) blocks the name. Rename action from "docvet" to "Docvet Check" to unblock marketplace listing.

- Rename `name` field in `action.yml` from `docvet` to `Docvet Check`

Test: CI only

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [x] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
One-line rename in `action.yml`. Consumers use `Alberto-Codes/docvet@v1` (repo path), not the marketplace display name, so no breaking change.

### Related
Unblocks GitHub Marketplace publishing for the docvet GitHub Action.