### PR TITLE
chore: migrate to single-branch (main-only) workflow

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -30,15 +30,15 @@ Read `.github/PULL_REQUEST_TEMPLATE.md` before composing the PR body. The body M
 
 ## Base Branch
 
-- PRs target `develop` unless explicitly told otherwise
-- Always run `git diff develop..HEAD` and `git log --oneline develop..HEAD` to understand the full scope before writing the PR body
+- PRs target `main` unless explicitly told otherwise
+- Always run `git diff main..HEAD` and `git log --oneline main..HEAD` to understand the full scope before writing the PR body
 
 ## Diff Before PR
 
 Before creating a PR, always:
 
-1. `git diff --stat develop..HEAD` — understand file scope
-2. `git log --oneline develop..HEAD` — understand commit history
+1. `git diff --stat main..HEAD` — understand file scope
+2. `git log --oneline main..HEAD` — understand commit history
 3. Read ALL commits (not just the latest) to write an accurate description
 
 ## No Co-Authored-By

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [main]
   push:
-    branches: [develop, main]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,13 +130,11 @@ Dev: `pytest`, `pytest-cov`, `pytest-mock`, `pytest-randomly`, `ruff`, `ty`
 
 ## Branching & Release
 
-- **`develop`**: Integration branch — all feature PRs merge here (squash merge)
-- **`main`**: Release branch — release-please watches here, publishes trigger from here
-- **develop → main**: Use **rebase and merge** (not merge commit, not squash) to preserve per-PR commits on develop for release-please changelog generation while maintaining linear history on main. Merge commits caused duplicate changelog entries (see [release-please#2476](https://github.com/googleapis/release-please/issues/2476)); squash merge loses per-PR granularity.
+- **`main`**: Single default branch — all feature PRs squash-merge here
+- **Feature branches**: `feat/<scope>-<description>`, squash-merged to main via PR
 - **release-please**: `googleapis/release-please-action@v4` on push to `main`. Config in `release-please-config.json`. Manifest in `.release-please-manifest.json`.
 - **Publishing**: OIDC trusted publishing to PyPI (no API tokens). Triggered by `release: [published]` event.
 - **Floating tag**: `v1` tag updated on each release for GitHub Action consumers.
-- **Syncing develop after release**: After merging a release-please PR to main, sync develop using **rebase** (not merge): `git checkout develop && git rebase origin/main && git push origin develop --force-with-lease`. Merge commits in develop's history block future rebase-merge PRs to main. If develop accumulates merge commits, hard-reset to main: `git reset --hard origin/main` then cherry-pick any develop-only commits.
 
 ## CI/CD Pipeline Lessons
 


### PR DESCRIPTION
The two-branch model (develop→main) created unnecessary friction: rebase-merge SHA divergence requiring force-push sync, redundant CI runs, and fighting release-please's single-branch design. This migrates to a main-only workflow where feature PRs squash-merge directly to main.

- Update CI workflow triggers from `[develop, main]` to `[main]` only
- Update CLAUDE.md branching section to document single-branch model
- Update `.claude/rules/pull-requests.md` to target `main` instead of `develop`
- Change GitHub default branch from `develop` to `main` (done via API)
- Delete stale `release-please--branches--develop--components--docvet` remote branch (done)

Test: CI only

Closes #116

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [x] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
The CI trigger change removes `develop` from both `push` and `pull_request` triggers. This is intentional — develop is archived.

### Related
- Issue #116 (migration checklist)
- Research: release-please recommends squash-merge and single-branch ([#2476](https://github.com/googleapis/release-please/issues/2476))