### PR TITLE
fix(ci): add retry logic to TestPyPI publish workflow

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -40,4 +40,17 @@ jobs:
           echo "Wheel contents clean — OK"
 
       - name: Publish to TestPyPI
-        run: uv publish --index testpypi
+        run: |
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt} of 3..."
+            if uv publish --index testpypi --check-url https://test.pypi.org/simple/; then
+              echo "Published successfully on attempt ${attempt}"
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Upload failed, retrying in 15s..."
+              sleep 15
+            fi
+          done
+          echo "::error::All 3 publish attempts failed"
+          exit 1


### PR DESCRIPTION
TestPyPI returns transient 503 errors during sdist upload even when
OIDC auth succeeds (wheel uploads fine, sdist gets 503'd). This has
caused every test-publish run to fail since launch, showing a red
deployment badge on the repo page.

- Add 3-attempt retry loop with 15s backoff between attempts
- Add `--check-url` to skip files already uploaded in partial attempts

Test: Trigger `workflow_dispatch` on main after merge

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Shell retry logic in the workflow — verify loop exits correctly on success
and propagates failure after 3 attempts.

### Related
- All 6 test-publish runs failed with various errors (503, SHA mismatch, missing index)