### PR TITLE
fix(ci): use env var for check-url to avoid flag conflict

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -40,10 +40,12 @@ jobs:
           echo "Wheel contents clean — OK"
 
       - name: Publish to TestPyPI
+        env:
+          UV_PUBLISH_CHECK_URL: https://test.pypi.org/simple/
         run: |
           for attempt in 1 2 3; do
             echo "Attempt ${attempt} of 3..."
-            if uv publish --index testpypi --check-url https://test.pypi.org/simple/; then
+            if uv publish --index testpypi; then
               echo "Published successfully on attempt ${attempt}"
               exit 0
             fi


### PR DESCRIPTION
Follow-up to #120. `--index` and `--check-url` are mutually exclusive
in `uv publish`, so the retry loop failed immediately on all 3 attempts.
Use `UV_PUBLISH_CHECK_URL` env var instead — this lets `--index` handle
OIDC token minting for the correct TestPyPI audience while the env var
enables skipping already-uploaded files from partial attempts.

- Replace `--check-url` flag with `UV_PUBLISH_CHECK_URL` env var
- Keep `--index testpypi` for correct OIDC audience

Test: Trigger `workflow_dispatch` on main after merge

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Verify env var approach works with `--index` flag for OIDC.

### Related
- #120 (retry logic, merged but had flag conflict)