### PR TITLE
fix(ci): drop check-url that conflicts with --index in uv publish

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -40,8 +40,6 @@ jobs:
           echo "Wheel contents clean — OK"
 
       - name: Publish to TestPyPI
-        env:
-          UV_PUBLISH_CHECK_URL: https://test.pypi.org/simple/
         run: |
           for attempt in 1 2 3; do
             echo "Attempt ${attempt} of 3..."


### PR DESCRIPTION
Follow-up to #121. `UV_PUBLISH_CHECK_URL` env var is treated
identically to `--check-url` by uv — still conflicts with `--index`.
Drop it and rely on retry logic alone for transient TestPyPI 503s.

- Remove `UV_PUBLISH_CHECK_URL` env var
- Retry loop with `--index testpypi` remains

Test: Trigger `workflow_dispatch` on main after merge

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Minimal change — just removes the conflicting env var.

### Related
- #120, #121 (previous attempts)