### PR TITLE
chore: add SECURITY.md vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release is supported with security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+| < Latest | No       |
+
+## Scope
+
+docvet is a static analysis tool that reads Python source files and calls `git` via subprocess. By design it:
+
+- Parses `.py` files using Python's `ast` module (no `eval`, no `exec`)
+- Runs `git diff`, `git blame`, and `git log` via `subprocess.run` with explicit argument lists (no shell expansion)
+- Does **not** make network requests, download packages, or execute analyzed code
+
+Reports about these expected behaviors are not security vulnerabilities. If you believe docvet's approach in these areas can be hardened, please open a regular issue.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through GitHub's [private vulnerability reporting](https://github.com/Alberto-Codes/docvet/security/advisories/new).
+
+Do **not** open a public issue for security vulnerabilities.
+
+## Disclosure
+
+Critical vulnerabilities will be disclosed via GitHub's [security advisory](https://github.com/Alberto-Codes/docvet/security) system.
+
+## Security Scanning
+
+This project runs [CodeQL](https://github.com/Alberto-Codes/docvet/actions/workflows/codeql.yml) on every pull request and weekly, scanning for command injection, XSS, and other OWASP vulnerability patterns.


### PR DESCRIPTION
Adds a security policy and enables GitHub's full security suite. Neither
interrogate nor pydoclint has a SECURITY.md — this puts docvet ahead of
both direct competitors on security posture.

- Add SECURITY.md with scope section (AST parsing and git subprocess are by design), supported versions, and private vulnerability reporting link
- Enable secret scanning + push protection, Dependabot security updates, and private vulnerability reporting via API
- Reference CodeQL scanning (added in PR #124) as active security infrastructure

Test: CI only — single markdown file, no code changes

Closes #102

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Scope section accurately describes docvet's attack surface
- GitHub security features already enabled via API (independent of this PR)

### Related
- #102, PR #124 (CodeQL)