### PR TITLE
docs: add social preview and update tagline

### DIFF
--- a/.github/social-preview.html
+++ b/.github/social-preview.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1280">
+<title>docvet social preview</title>
+<style>
+  *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+  html::-webkit-scrollbar, body::-webkit-scrollbar { display: none; }
+
+  html {
+    background: #0a0215;
+  }
+
+  html, body {
+    width: 1280px;
+    height: 640px;
+    overflow: hidden;
+    scrollbar-width: none;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    color: #fff;
+    background: linear-gradient(145deg, #1e0a3c 0%, #130626 40%, #0a0215 100%);
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Subtle radial glow behind content */
+  body::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -55%);
+    width: 800px;
+    height: 500px;
+    background: radial-gradient(ellipse, rgba(124, 58, 237, 0.12) 0%, transparent 70%);
+    pointer-events: none;
+  }
+
+  /* Fine noise texture overlay */
+  body::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+    opacity: 0.4;
+    pointer-events: none;
+  }
+
+  .card {
+    position: relative;
+    z-index: 1;
+    width: 1280px;
+    height: 640px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 64px 128px;
+    gap: 0;
+  }
+
+  /* Shield icon */
+  .shield {
+    position: relative;
+    width: 56px;
+    height: 64px;
+    margin-bottom: 28px;
+    flex-shrink: 0;
+  }
+
+  .shield::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, #7C3AED 0%, #6D28D9 100%);
+    clip-path: polygon(50% 0%, 100% 12%, 100% 65%, 50% 100%, 0% 65%, 0% 12%);
+  }
+
+  /* Checkmark inside shield */
+  .shield::after {
+    content: '';
+    position: absolute;
+    top: 22px;
+    left: 16px;
+    width: 24px;
+    height: 14px;
+    border-left: 3.5px solid #fff;
+    border-bottom: 3.5px solid #fff;
+    transform: rotate(-45deg);
+  }
+
+  .title {
+    font-size: 96px;
+    font-weight: 800;
+    letter-spacing: -3px;
+    line-height: 1;
+    margin-bottom: 16px;
+    flex-shrink: 0;
+  }
+
+  .tagline {
+    font-size: 27px;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.75);
+    letter-spacing: -0.2px;
+    line-height: 1.3;
+    margin-bottom: 44px;
+    flex-shrink: 0;
+  }
+
+  .question {
+    font-size: 36px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.95);
+    letter-spacing: -0.5px;
+    line-height: 1;
+    margin-bottom: 44px;
+    flex-shrink: 0;
+  }
+
+  .install {
+    font-size: 18px;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.4);
+    letter-spacing: 0.5px;
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "Segoe UI Mono", Menlo, monospace;
+    flex-shrink: 0;
+  }
+</style>
+</head>
+<body>
+  <div class="card">
+    <div class="shield"></div>
+    <div class="title">docvet</div>
+    <div class="tagline">Your AI reads your docstrings.</div>
+    <div class="question">Are they right?</div>
+    <div class="install">pip install docvet</div>
+  </div>
+</body>
+</html>

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ coverage.xml
 # mkdocs build output
 /site/
 
+# Generated assets
+social-preview.png
+
 # OS
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 # docvet
 
-**ruff checks how your docstrings look. interrogate checks if they exist. docvet checks if they're right.**
+**Better docstrings, better AI.**
 
-Existing tools cover presence and style. docvet delivers the layers they miss:
+ruff checks how your docstrings look. interrogate checks if they exist. docvet checks if they're right. Existing tools cover presence and style — docvet delivers the layers they miss:
 
 | Layer | Check | ruff | interrogate | pydoclint | **docvet** |
 |-------|-------|------|-------------|-----------|------------|

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -2,7 +2,7 @@
 title: Getting Started
 ---
 
-# The docstring checks that linters miss.
+# Better docstrings, better AI.
 
 [![PyPI version](https://img.shields.io/pypi/v/docvet)](https://pypi.org/project/docvet/)
 [![Python versions](https://img.shields.io/pypi/pyversions/docvet)](https://pypi.org/project/docvet/)


### PR DESCRIPTION
The default GitHub social preview showed "0 Stars, 0 Forks, 13 Issues" — not the first impression we want for a LinkedIn announcement. This adds a custom social preview and updates the project tagline across surfaces.

Messaging strategy: the social preview card uses a provocative hook ("Your AI reads your docstrings. Are they right?") to stop the scroll, while the README and docs site anchor with the tagline ("Better docstrings, better AI.").

- Add social preview HTML source at `.github/social-preview.html` (1280x640, dark purple gradient, CSS-only shield icon)
- Update README lead tagline to "Better docstrings, better AI."
- Update mkdocs site h1 to match
- Gitignore generated `social-preview.png` (binary lives on GitHub Settings, not in repo)

Test: Visual — open `.github/social-preview.html` in browser at 1280x640. Regenerate PNG with `google-chrome-stable --headless --screenshot=social-preview.png --window-size=1280,660 --hide-scrollbars .github/social-preview.html` then crop to 1280x640.

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Tagline copy on README and mkdocs site. Social preview HTML design.

### Related
Part of Epic 14 (Adoption & Integration)