### PR TITLE
chore(ci): deploy docs on release only, not every push to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,8 @@
 name: Deploy Documentation
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Docs should match the published version, not bleed ahead of it. Every squash-merge to main was triggering a full docs build + deploy even when zero doc files changed.

- Change docs workflow trigger from `push: branches: [main]` to `release: types: [published]`
- Keep `workflow_dispatch` for manual deploys when needed

Test: CI only — workflow syntax validated by actionlint pre-commit hook.

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Workflow trigger change — confirm `release: types: [published]` fires when release-please merges.

### Related
Release-please workflow in `.github/workflows/release-please.yml`