### PR TITLE
chore(bmad): add Epic 29 planning and close Epic 27 retrospective

### DIFF
--- a/_bmad-output/implementation-artifacts/epic-27-retro-2026-02-28.md
+++ b/_bmad-output/implementation-artifacts/epic-27-retro-2026-02-28.md
@@ -1,0 +1,124 @@
+# Epic 27 Retrospective — Freshness Accuracy
+
+**Date:** 2026-02-28
+**Facilitator:** Bob (Scrum Master)
+**Participants:** Alberto-Codes (Project Lead), Alice (Product Owner), Charlie (Senior Dev), Dana (QA Engineer), Elena (Junior Dev)
+
+---
+
+## Epic Summary
+
+| Metric | Value |
+|--------|-------|
+| Stories | 1/1 completed (100%) |
+| Story type | Bug fix — freshness diff false positive elimination |
+| Debug sessions | 0 (zero-debug) |
+| Test suite | 988 (up from 971, +17 net new tests) |
+| Code review findings | 5 total (1 HIGH, 1 MEDIUM→LOW, 2 LOW, 1 pre-existing) |
+| PR review findings | 1 (Copilot — convention compliance) |
+| Tech debt items | 0 new |
+| Production incidents | 0 |
+| GitHub Issues closed | #218 |
+| SonarQube | 0 new issues |
+
+### Stories
+
+| Story | Title | Type | Debug Sessions | Review Findings |
+|-------|-------|------|---------------|-----------------|
+| 27.1 | Fix hunk-to-symbol false positives | Bug fix | 0 | 5 (adversarial) + 1 (Copilot PR) — all fixed |
+
+---
+
+## Successes
+
+- **Story spec quality drove zero-debug implementation** — The "Implementation Approach" section provided pseudocode that mapped nearly 1:1 to the final code. Root cause analysis, anti-patterns list, and edge cases were all documented upfront. This extends the zero-debug streak to 20+ consecutive stories (Epics 22-27).
+- **Multi-layer review caught 6 findings with zero overlap** — Four distinct review layers each caught unique issue categories: adversarial review (CC, dead code, stale comments, notes count), party mode (severity calibration — downgraded M1), Copilot PR review (convention compliance — untested helper), codecov (uncovered multi-file diff branch). No redundancy between layers.
+- **Strong test coverage for a targeted fix** — 17 net new tests (11 unit + 1 integration + 4 direct helper + 1 coverage) for a single-function refactor. Test matrix covered context-line exclusion, no-newline markers, multi-file diffs, deletion line counting, and false-positive regression scenarios.
+- **Interactive demo proved the fix on real code** — Modified `_diff_line_delta` in the actual codebase and ran `docvet freshness` to demonstrate that the adjacent `_parse_diff_hunks` was not falsely flagged. Proof beyond test fixtures.
+- **Clean SonarQube scan post-merge** — Zero new issues introduced. CC reduced via `_diff_line_delta()` extraction during code review.
+
+---
+
+## Challenges
+
+- **Dev agent CC self-assessment inaccurate** — Story completion notes claimed CC ~11; adversarial review measured CC=18 (50% underestimate). The dev agent lacks visibility into CC during implementation — only the review workflow runs the analyzer.
+- **Dead code created during implementation** — `_make_diff_with_body()` helper was defined but never called in any test. Caught in adversarial review, repurposed (3 tests refactored to use it) rather than deleted per party mode consensus.
+- **Convention compliance missed by dev agent and adversarial review** — `_diff_line_delta` was the only private helper not directly imported and tested in the test file. Only Copilot PR review caught this pattern deviation.
+
+---
+
+## Key Insights
+
+1. **Story spec quality remains the #1 velocity multiplier** — The "Implementation Approach" pseudocode pattern continues to produce zero-debug implementations. When the thinking is done before the typing, debugging becomes unnecessary.
+2. **Multi-layer review is complementary, not redundant** — Each layer catches a distinct category: adversarial → correctness/complexity, party mode → judgment/severity, Copilot → convention/pattern, codecov → coverage gaps. Skipping any layer leaves a blind spot.
+3. **CC self-assessment during implementation is unreliable** — Dev agents should verify CC with `analyze_code_snippet` before claiming values in completion notes. Review is the safety net, but catching CC issues earlier saves a review round-trip.
+
+---
+
+## Previous Retro Follow-Through (Epic 26)
+
+| # | Action Item | Status |
+|---|-------------|--------|
+| 1 | Precision language review pass for docs-only stories | N/A — Epic 27 was a code fix epic |
+| 2 | Mermaid browser verification as standard gate | N/A — no Mermaid diagrams in Epic 27 |
+
+**Applicable action items: 0/2** (both docs-specific, not applicable to code-fix epic)
+
+**Carried Forward from Epic 26:**
+
+| Item | Status |
+|------|--------|
+| CLAUDE.md stale test structure section | Still backlog |
+| `test_exports.py` missing `docvet.lsp` module | Still backlog |
+
+**Follow-through trend:** 4/4 → 2/4 → 1/4 → 3/3 → 3/3 → 3/3 → 3/3 → 4/6 → 7/8 → 2/2 → 1/1 → N/A (0 applicable)
+
+---
+
+## Action Items
+
+### Process Improvements
+
+1. **Run `analyze_code_snippet` during dev-story, not just code review**
+   - Owner: Bob (SM) — add as standard task in story template for code-changing stories
+   - Success criteria: Dev agent runs SonarQube snippet analysis on modified functions before marking story done
+   - Evidence: CC=18 was invisible to the dev agent until adversarial review ran the analyzer
+
+2. **Continue multi-layer review on all non-trivial stories**
+   - Owner: All
+   - Success criteria: Adversarial review + party mode (when judgment calls needed) + Copilot PR review as standard practice
+   - Evidence: 4 review layers, 6 findings, zero overlap — each layer is load-bearing
+
+### Technical Debt
+
+None new from Epic 27.
+
+**Still carried forward:**
+- CLAUDE.md stale test structure section (from Epic 25 review)
+- `test_exports.py` missing `docvet.lsp` module (from Epic 25 review)
+- `cli.py:338` nested ternary S3358 (GitHub issue #204)
+
+### Team Agreements
+
+- Story spec "Implementation Approach" with pseudocode is the standard for code-changing stories — proven zero-debug enabler
+- CC self-assessment by the dev agent is unreliable — always verify with `analyze_code_snippet` before claiming CC values
+- Review layers are complementary, not redundant — don't skip any layer thinking another will catch it
+
+---
+
+## Readiness Assessment
+
+- Testing & Quality: 988 tests passing, 100% freshness.py coverage, zero docvet findings
+- Deployment: PR #219 squash-merged to main, live on next release
+- Stakeholder Acceptance: Bug fix — users benefit on next release
+- Technical Health: Stable, zero new concerns
+- Unresolved Blockers: None
+
+---
+
+## Next Steps
+
+1. No Epic 28 defined — full product roadmap complete (27 epics, 54 stories)
+2. Review action items in next standup
+3. Address carried-forward tech debt as maintenance work
+4. Resolve GitHub issue #204 (cli.py nested ternary) to clear SonarQube quality gate

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -229,4 +229,4 @@ development_status:
   # Epic 27: Freshness Accuracy
   epic-27: done
   27-1-fix-hunk-to-symbol-false-positives: done
-  epic-27-retrospective: optional
+  epic-27-retrospective: done  # 2026-02-28

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -3,12 +3,16 @@ stepsCompleted:
   - 'step-01-validate-prerequisites'
   - 'step-02-design-epics'
   - 'step-03-create-stories'
+  - 'step-02-design-epics-phase3'
+  - 'step-03-create-stories-phase3'
+  - 'step-04-final-validation-phase3'
 inputDocuments:
   - '_bmad-output/planning-artifacts/prd.md'
   - '_bmad-output/planning-artifacts/architecture.md'
   - '_bmad-output/planning-artifacts/epics-cli-ux.md'
   - '_bmad-output/planning-artifacts/prd-validation-report.md'
   - 'GitHub Issues: #72, #148, #149, #150, #154, #157, #158, #160, #163, #164, #176, #181, #182, #186, #187, #188, #189, #190, #191'
+  - 'Phase 3 GitHub Issues (Tiers 1-3): #204, #208, #207, #206, #154, #220, #221'
 ---
 
 # docvet - Epic Breakdown
@@ -84,10 +88,16 @@ FR-GH189: CI shall detect when source files change without corresponding docs pa
 FR-GH190: Docs site shall include at least one Mermaid architecture diagram
 FR-GH148: Exclude configuration shall support negation patterns (!pattern)
 
+**Phase 3 — From GitHub Issues (Tiers 1-3, 2026-02-28):**
+FR-GH204: Replace nested conditional expression (S3358) in `_output_and_exit` format resolution with flat if/elif/else to clear SonarQube quality gate ERROR
+FR-GH208: Add `docvet.lsp` to `_ALL_DOCVET_MODULES` list in `tests/unit/test_exports.py` so export verification includes the LSP module
+FR-GH207: Update CLAUDE.md test structure tree — remove stale references to `test_freshness_diff.py`, `test_freshness_drift.py`, and `stale_signature.py` fixture
+FR-GH206: Document three CLI output features in `docs/site/cli-reference.md`: progress bar (TTY vs piped), per-check `--verbose` timing, and "Vetted N files" summary format
+FR-GH154: Create new docs page with agent workflow loop diagram, setup instructions, before/after examples, and CI integration guidance
+
 **Backlog/Future (tracked but not scheduled):**
 FR-GH149: MCP server for agentic AI integration
 FR-GH150: `docvet init` command for agent-ready project scaffolding
-FR-GH154: Agent workflow example page on docs site
 FR-GH157: GitHub Action for PR inline docstring comments
 FR-GH158: mkdocs-material + mkdocstrings example project template
 FR-GH160: VS Code extension for docstring diagnostics
@@ -139,6 +149,12 @@ NFR-UX6: All 729+ existing tests continue passing
 NFR-UX7: --format markdown and --output work correctly with summary
 NFR-UX8: Zero-file edge cases produce meaningful summary
 
+**Phase 3 — From GitHub Issues (2026-02-28):**
+NFR-NEW1: SonarQube quality gate must return to PASSED — zero new violations on main (drives FR-GH204)
+NFR-NEW2: `docvet check --all` passes on own codebase with zero findings (dogfooding)
+NFR-NEW3: `mkdocs build --strict` passes with zero warnings after docs changes
+NFR-NEW4: All existing tests continue passing with zero regressions
+
 ### Additional Requirements
 
 **From Architecture Document:**
@@ -150,6 +166,10 @@ NFR-UX8: Zero-file edge cases produce meaningful summary
 - No cross-check imports between check modules
 - Checks are isolated — no shared mutable state
 - All public modules define __all__ exports (API stability)
+
+**Phase 3 — Process Improvements (2026-02-28):**
+- AR-GH220: Add `analyze_code_snippet` as standard task in BMAD story template for code-changing stories — run SonarQube snippet analysis on modified functions before marking done (Source: #220, Epic 27 retro)
+- AR-GH221: Document multi-layer review practice (adversarial + party mode + Copilot + codecov) as standard for non-trivial stories (Source: #221, Epic 27 retro)
 
 **From CLI UX Research (Party Mode Session 2026-02-26):**
 - "Vetted" chosen as brand verb — unique in Python tool ecosystem
@@ -193,10 +213,16 @@ NFR-UX8: Zero-file edge cases produce meaningful summary
 | FR-UX14 | 28 | Quiet dual-registration pattern |
 | FR-UX15 | 28 | Individual subcommands follow three-tier output model |
 | FR-UX16 | 28 | Subcommand summary with own check name only |
+| FR-GH204 | Standalone fix | Replace nested ternary — SonarQube S3358 (ships outside epic) |
+| FR-GH208 | 29 | Add docvet.lsp to test_exports.py |
+| FR-GH207 | 29 | Update CLAUDE.md test structure |
+| AR-GH220 | 29 | Add snippet analysis to story template |
+| AR-GH221 | 29 | Document multi-layer review practice |
+| FR-GH206 | 29 | CLI reference — progress, timing, summary |
+| FR-GH154 | 29 | Agent workflow docs page |
 | FR-GH148 | Backlog | Negation pattern support for exclude config |
 | FR-GH149 | Backlog | MCP server for agentic AI integration |
 | FR-GH150 | Backlog | `docvet init` command |
-| FR-GH154 | Backlog | Agent workflow example docs page |
 | FR-GH157 | Backlog | GitHub Action for PR inline comments |
 | FR-GH158 | Backlog | mkdocs + mkdocstrings example template |
 | FR-GH160 | Backlog | VS Code extension |
@@ -205,6 +231,15 @@ NFR-UX8: Zero-file edge cases produce meaningful summary
 | FR-GH72 | Backlog | WebMCP integration |
 
 ## Epic List
+
+### Standalone Fix (pre-epic): fix(cli) nested ternary — #204
+SonarQube quality gate ERROR (S3358). Ships immediately as a standalone PR, not wrapped in epic ceremony.
+**FRs covered:** FR-GH204
+
+### Epic 29: Post-Launch Polish
+Maintainers and contributors work with complete test coverage, accurate project documentation, improved development process, and users find accurate CLI reference plus a clear agent workflow guide.
+**FRs covered:** FR-GH208, FR-GH207, AR-GH220, AR-GH221, FR-GH206, FR-GH154
+**GitHub Issues:** #208, #207, #220, #221, #206, #154
 
 ### Epic 25: Development Process & CI Quality
 The development process prevents documentation drift and CI provides reliable, consistent quality signals. BMAD workflows enforce docs-site updates at story creation and code review time, CI detects source-without-docs changes, and testing/coverage infrastructure is standardized.
@@ -885,3 +920,171 @@ AC 7:
 **Implementation notes:**
 - Stories 28.1-28.4 each update tests for their own scope; this story catches any remaining test migrations and handles all docs updates
 - Edge case tests may already exist from prior stories — this story ensures comprehensive coverage
+
+---
+
+## Standalone Fix (pre-epic): fix(cli) nested ternary — #204
+
+SonarQube quality gate ERROR (S3358). Ships immediately as a standalone PR:
+
+> **fix(cli): replace nested ternary in `_output_and_exit` format resolution**
+> Replace nested conditional at `cli.py:338` with flat if/elif/else. Closes #204. Quality gate returns to PASSED.
+
+**FRs covered:** FR-GH204
+
+---
+
+## Epic 29: Post-Launch Polish
+
+Maintainers and contributors work with complete test coverage, accurate project documentation, improved development process, and users find accurate CLI reference plus a clear agent workflow guide.
+
+### Story 29.1: Test & Documentation Hygiene
+
+As a **docvet contributor**,
+I want the test export coverage to include all public modules and the CLAUDE.md test structure to reflect the current codebase,
+So that AI agents and contributors get accurate project context.
+
+**FRs covered:** FR-GH208, FR-GH207
+
+**Acceptance Criteria:**
+
+AC 1:
+**Given** the `_ALL_DOCVET_MODULES` list in `tests/unit/test_exports.py`
+**When** `uv run pytest tests/unit/test_exports.py` is run before any changes
+**Then** confirm the export test fails or is incomplete for `docvet.lsp` (verify gap exists)
+**And** after adding `docvet.lsp` to the list, the test passes
+
+AC 2:
+**Given** the Architecture → Test Structure section in `CLAUDE.md`
+**When** updated
+**Then** stale references to `test_freshness_diff.py`, `test_freshness_drift.py`, and `stale_signature.py` fixture are removed
+**And** the tree reflects the current `tests/` directory structure
+
+AC 3:
+**Given** all changes are applied
+**When** `uv run pytest` is executed
+**Then** all tests pass with zero regressions
+
+**Implementation notes:**
+- #208: add one string (`"docvet.lsp"`) to the module list
+- #207: run `find tests/` to get current tree, replace the markdown block in CLAUDE.md
+- Single PR, single commit
+
+---
+
+### Story 29.2: Development Process Updates
+
+As a **docvet contributor using BMAD workflows**,
+I want the story template to include SonarQube snippet analysis as a standard task and the multi-layer review practice to be documented,
+So that quality issues are caught earlier in the development cycle and review practices are consistent.
+
+**FRs covered:** AR-GH220, AR-GH221
+
+**Acceptance Criteria:**
+
+AC 1:
+**Given** the BMAD dev-story workflow at `_bmad/bmm/workflows/4-implementation/dev-story/`
+**When** the post-implementation quality checks step is updated
+**Then** the step includes a task to run `analyze_code_snippet` on modified functions before marking the story done
+
+AC 2:
+**Given** the multi-layer review practice (adversarial review + party mode + Copilot PR review + codecov)
+**When** documented as a new file at `.claude/rules/review-practice.md`
+**Then** the file describes the four review layers, when to apply them (non-trivial stories), and the evidence that each layer catches distinct issue categories with zero overlap
+
+AC 3:
+**Given** the updated workflow
+**When** a contributor runs `/bmad-bmm-dev-story`
+**Then** the SonarQube analysis step appears in the workflow execution
+
+**Implementation notes:**
+- #220: edit the appropriate step file in `_bmad/bmm/workflows/4-implementation/dev-story/steps/`
+- #221: create `.claude/rules/review-practice.md` with the four-layer review practice
+- Single PR covering both template/process changes
+
+---
+
+### Story 29.3: CLI Reference Documentation Update
+
+As a **docvet user reading the CLI reference**,
+I want the docs to accurately describe progress bar behavior, per-check timing, and the vetted summary format,
+So that I understand what output to expect in different contexts (TTY, piped, verbose).
+
+**FRs covered:** FR-GH206
+
+**Acceptance Criteria:**
+
+AC 1:
+**Given** `docs/site/cli-reference.md`
+**When** updated
+**Then** it documents progress bar behavior: displays on stderr when connected to a TTY, suppressed when piped or redirected
+
+AC 2:
+**Given** the CLI reference
+**When** a user reads the verbose mode section
+**Then** per-check timing is documented (e.g., `enrichment: 42 files in 0.3s`)
+**And** total execution time in the summary line is documented
+
+AC 3:
+**Given** the CLI reference
+**When** a user reads the output section
+**Then** the vetted summary line format is documented, captured from a real `docvet check --all` run against the current released CLI (v1.6.1+)
+
+AC 4:
+**Given** the updated docs site
+**When** `mkdocs build --strict` is executed
+**Then** the build succeeds with zero warnings
+
+**Implementation notes:**
+- #206: three features from Epics 20-21 (progress bar PR #139, per-check timing PR #140, vetted summary PR #141) — all shipped in v1.6.x
+- Document current released behavior; run `docvet check --all` to capture actual output
+- Single page edit, no new pages needed
+
+---
+
+### Story 29.4: Agent Workflow Documentation Page
+
+As a **developer evaluating docvet for AI-assisted workflows**,
+I want a dedicated docs page showing exactly where docvet fits in the agent development loop,
+So that I can set up docvet in my project and configure my AI agent to use it effectively.
+
+**FRs covered:** FR-GH154
+
+**Acceptance Criteria:**
+
+AC 1:
+**Given** the docs site navigation
+**When** a user browses the top-level nav
+**Then** an "Agent Workflow" page is visible, placed after the AI Agent Integration page in `mkdocs.yml`
+
+AC 2:
+**Given** the agent workflow page
+**When** a user reads the workflow section
+**Then** a Mermaid diagram illustrates the loop: code change → `docvet check` → read findings → fix docstrings → commit clean
+**And** the diagram follows `.claude/rules/mermaid.md` conventions and uses styling consistent with the existing `docs/site/architecture.md` diagram
+
+AC 3:
+**Given** the agent workflow page
+**When** a user reads the setup section
+**Then** instructions cover pyproject.toml `[tool.docvet]` configuration and at minimum a CLAUDE.md agent instruction snippet, with optional examples for other agents (Cursor, Copilot) if tested
+
+AC 4:
+**Given** the agent workflow page
+**When** a user reads the examples section
+**Then** at least one before/after example shows: agent changes a function signature, docvet catches stale docstring, agent fixes it
+
+AC 5:
+**Given** the agent workflow page
+**When** a user reads the CI section
+**Then** GitHub Actions integration is documented showing how `docvet check` catches agent-generated PRs with docstring issues
+
+AC 6:
+**Given** the updated docs site
+**When** `mkdocs build --strict` is executed
+**Then** the build succeeds with zero warnings
+
+**Implementation notes:**
+- #154: creative deliverable — new page, not an edit
+- Add to mkdocs.yml nav after AI Agent Integration
+- Follow `.claude/rules/mermaid.md` for diagram styling; reference `docs/site/architecture.md` for visual consistency
+- Cross-link from existing AI Agent Integration page


### PR DESCRIPTION
Triage 22 open GitHub issues: close 6 as already resolved (validated
against source/docs/tests with commit references), plan 7 into Epic 29
(Post-Launch Polish) with 4 stories plus a standalone quality gate fix,
defer 9 to backlog.

- Close #176, #186, #190, #191, #182, #181 with resolution comments
- Add Epic 29 stories (29.1-29.4) to epics.md with party-mode-refined ACs
- Decouple #204 as standalone fix (SonarQube gate blocker)
- Tag all 7 planned issues with epic/story assignments on GitHub
- Mark Epic 27 retrospective done in sprint-status.yaml
- Add Epic 27 retrospective artifact

Test: CI only (no source code changes)

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Planning artifact quality — story ACs were refined through two party-mode sessions with full agent roster.

### Related
- Issues closed: #176, #186, #190, #191, #182, #181
- Issues planned: #204, #208, #207, #220, #221, #206, #154
- Issues deferred: #149, #150, #157, #158, #160, #163, #164, #148, #72