### PR TITLE
fix(cli): replace nested ternary in _output_and_exit format resolution

### DIFF
--- a/src/docvet/cli.py
+++ b/src/docvet/cli.py
@@ -295,9 +295,10 @@ def _output_and_exit(
 
     Implements the unified output pipeline: resolves ``no_color`` from
     environment and TTY state, optionally prints a verbose header to
-    stderr for multi-check runs, resolves the output format via an
-    explicit identity check on the ``--format`` and ``--output`` options, delegates to
-    :func:`_emit_findings` for format dispatch, and raises
+    stderr for multi-check runs, resolves the output format via a
+    three-tier precedence chain (explicit ``--format``, then
+    ``--output`` implies markdown, then terminal default), delegates
+    to :func:`_emit_findings` for format dispatch, and raises
     ``typer.Exit`` with the appropriate exit code.
 
     Args:
@@ -332,11 +333,12 @@ def _output_and_exit(
         sys.stderr.write(format_verbose_header(file_count, checks))
 
     # 4. Resolve format
-    resolved_fmt = (
-        fmt_opt
-        if fmt_opt is not None
-        else ("markdown" if output_path is not None else "terminal")
-    )
+    if fmt_opt is not None:
+        resolved_fmt = fmt_opt
+    elif output_path is not None:
+        resolved_fmt = "markdown"
+    else:
+        resolved_fmt = "terminal"
 
     # 5. Emit findings
     _emit_findings(resolved_fmt, all_findings, output_path, no_color, file_count)


### PR DESCRIPTION
SonarQube S3358 (nested conditional expression) flagged `_output_and_exit` line 338, causing the quality gate to report ERROR (1 new violation, 0 threshold). The nested ternary was introduced in `40c86db` during a CC refactoring that collapsed a flat `if/elif/else` into a single expression.

- Replace nested ternary with flat `if/elif/else` precedence chain
- Update docstring to describe three-tier format resolution (explicit `--format`, then `--output` implies markdown, then terminal default)

Test: `uv run pytest tests/unit/test_cli.py -x` (198 passed, all 3 format resolution branches covered by existing tests)

Closes #204

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Behavior-preserving refactor — the flat `if/elif/else` is semantically identical to the nested ternary. SonarQube scan confirms quality gate is now OK (0 new violations, 97.4% new coverage).

### Related
- Introduced by: `40c86db` (PR #179)
- SonarQube rule: `python:S3358`