### PR TITLE
fix(enrichment): detect rST :: indented code blocks in prefer-fenced-code-blocks rule

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-204-fix-nested-ternary.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-204-fix-nested-ternary.md
@@ -1,0 +1,121 @@
+---
+title: 'Fix nested ternary in _output_and_exit format resolution'
+slug: '204-fix-nested-ternary'
+created: '2026-02-28'
+status: 'completed'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack: ['Python 3.12+', 'typer', 'ruff', 'pytest']
+files_to_modify: ['src/docvet/cli.py']
+code_patterns: ['flat if/elif/else for multi-branch assignment', 'numbered comment steps in _output_and_exit']
+test_patterns: ['TestOutputAndExit class with _make_ctx helper and _call wrapper']
+---
+
+# Tech-Spec: Fix nested ternary in _output_and_exit format resolution
+
+**Created:** 2026-02-28
+
+## Overview
+
+### Problem Statement
+
+SonarQube flags `python:S3358` (nested conditional expression) on `src/docvet/cli.py:335-339`. The nested ternary was introduced in `40c86db` (PR #179) during a cognitive complexity refactoring. It causes the quality gate to report ERROR due to 1 new violation against a 0 threshold.
+
+### Solution
+
+Replace the nested ternary with a flat `if/elif/else` chain. This is behavior-preserving — three branches, three outcomes, identical logic. The flat chain actually *lowers* cognitive complexity compared to the nested ternary (no nesting penalty on `elif`), so CC improves slightly rather than regressing. The original `40c86db` commit introduced the ternary alongside an `_emit_findings` extraction as a coordinated CC reduction — reverting only the ternary half is safe because the flat chain scores lower CC, not higher.
+
+### Scope
+
+**In Scope:**
+- Replace the nested ternary at `cli.py:334-339` with a flat `if/elif/else`
+
+**Out of Scope:**
+- No helper function extraction
+- No new tests (existing tests cover all three branches)
+- No other refactoring in `_output_and_exit` or elsewhere
+
+## Context for Development
+
+### Codebase Patterns
+
+- `_output_and_exit` uses numbered comment steps (`# 1.` through `# 6.`) for its pipeline stages — preserve the `# 4. Resolve format` comment
+- Local variable assignment pattern: `resolved_fmt = ...` in each branch, consistent with other assignments in the function
+- Local variable assignment via flat `if/elif/else` is the idiomatic pattern in this codebase for multi-branch resolution
+
+### Files to Reference
+
+| File | Purpose |
+| ---- | ------- |
+| `src/docvet/cli.py:334-339` | Target: nested ternary in `_output_and_exit` step 4 |
+| `tests/unit/test_cli.py:1618` | `test_terminal_format_is_default_when_format_not_set` — branch 3 (`"terminal"`) |
+| `tests/unit/test_cli.py:1625` | `test_format_markdown_selects_format_markdown` — branch 1 (explicit `fmt_opt`) |
+| `tests/unit/test_cli.py:1642` | `test_output_without_format_defaults_to_markdown_for_file` — branch 2 (`"markdown"` fallback) |
+
+### Technical Decisions
+
+- **Flat `if/elif/else` over helper function**: Three branches is too trivial to extract. A helper would be over-engineering.
+- **No match/case**: Overkill for a simple precedence check with `is not None` guards.
+- **No new tests**: All three branches are already covered by existing `TestOutputAndExit` tests (verified in Step 2).
+
+## Implementation Plan
+
+### Tasks
+
+- [x] Task 1: Replace nested ternary with flat `if/elif/else`
+  - File: `src/docvet/cli.py`
+  - Action: Replace lines 334-339 (the `# 4. Resolve format` block) with:
+    ```python
+    # 4. Resolve format
+    if fmt_opt is not None:
+        resolved_fmt = fmt_opt
+    elif output_path is not None:
+        resolved_fmt = "markdown"
+    else:
+        resolved_fmt = "terminal"
+    ```
+  - Notes: Preserves the `# 4. Resolve format` comment. No other lines in the function change.
+
+- [x] Task 2: Run quality checks
+  - Action: Verify no regressions
+  - Commands:
+    - `uv run ruff check src/docvet/cli.py`
+    - `uv run ruff format --check src/docvet/cli.py`
+    - `uv run ty check`
+    - `uv run pytest tests/unit/test_cli.py -x`
+
+- [x] Task 3: Verify S3358 resolution via SonarQube snippet analyzer
+  - Action: Run `analyze_code_snippet` on the modified `cli.py` to confirm S3358 is no longer reported
+  - Notes: The MCP snippet analyzer provides fast feedback. The full scanner (dashboard) is the source of truth but requires a merge-to-main scan cycle.
+
+### Acceptance Criteria
+
+- [ ] AC1: Given the nested ternary is replaced with flat `if/elif/else`, when `_output_and_exit` is called with `fmt_opt=None` and `output_path=None`, then format resolves to `"terminal"`.
+- [ ] AC2: Given the nested ternary is replaced with flat `if/elif/else`, when `_output_and_exit` is called with `fmt_opt=None` and `output_path=Path("out.md")`, then format resolves to `"markdown"`.
+- [ ] AC3: Given the nested ternary is replaced with flat `if/elif/else`, when `_output_and_exit` is called with `fmt_opt="markdown"`, then format resolves to `"markdown"` (explicit override).
+- [ ] AC4: All existing tests in `tests/unit/test_cli.py` pass without modification.
+- [ ] AC5: `ruff check`, `ruff format --check`, and `ty check` pass on the modified file.
+- [ ] AC6: SonarQube `analyze_code_snippet` on the modified `cli.py` reports no S3358 finding.
+
+## Additional Context
+
+### Dependencies
+
+None. Pure refactoring of existing code.
+
+### Testing Strategy
+
+Existing tests only — no new tests required. Three existing tests in `TestOutputAndExit` (lines 1618, 1625, 1642) cover all three format resolution branches. Run `uv run pytest tests/unit/test_cli.py -x` to verify.
+
+### Notes
+
+- Introduced by: `40c86db` (PR #179 — refactor(cli): reduce _output_and_exit cognitive complexity)
+- SonarQube rule: `python:S3358` — nested conditional expression
+- GitHub issue: 204
+- Risk: Near zero — behavior-preserving, single-site change, full test coverage
+
+## Review Notes
+
+- Adversarial review completed (spec review + code review)
+- Spec review findings: 12 total, 5 fixed (F1-F5), 7 noise
+- Code review findings: 12 total, 0 fixed, 12 noise (confirmed by team consensus)
+- Resolution approach: skip (all code findings noise — reviewer lacked SonarQube context by design)

--- a/_bmad-output/implementation-artifacts/tech-spec-225-fix-rst-indented-block-detection.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-225-fix-rst-indented-block-detection.md
@@ -1,0 +1,222 @@
+---
+title: 'Fix prefer-fenced-code-blocks to detect :: indented code blocks'
+slug: '225-fix-rst-indented-block-detection'
+created: '2026-03-01'
+status: 'ready-for-dev'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack: ['python', 'ast', 'regex']
+files_to_modify:
+  - 'src/docvet/checks/enrichment.py'
+  - 'tests/unit/checks/test_enrichment.py'
+  - 'src/docvet/__init__.py'
+  - 'src/docvet/ast_utils.py'
+  - 'src/docvet/cli.py'
+  - 'src/docvet/config.py'
+  - 'src/docvet/discovery.py'
+  - 'src/docvet/lsp.py'
+  - 'src/docvet/reporting.py'
+  - 'src/docvet/checks/_finding.py'
+  - 'src/docvet/checks/coverage.py'
+  - 'src/docvet/checks/freshness.py'
+  - 'src/docvet/checks/griffe_compat.py'
+  - 'docs/main.py'
+  - 'docs/site/rules/prefer-fenced-code-blocks.md'
+  - 'docs/rules.yml'
+  - 'docs/site/checks/enrichment.md'
+  - 'docs/site/configuration.md'
+code_patterns:
+  - 'table-driven dispatch via _RULE_DISPATCH'
+  - 'helper extraction for CC control'
+  - '_extract_section_content for section scoping'
+test_patterns:
+  - 'source factory fixtures in conftest.py'
+  - 'one test file per check module'
+  - 'assert all Finding fields'
+  - 'module-level symbol: inline [s for s in symbols if s.kind == "module"][0] pattern (no helper)'
+---
+
+# Tech-Spec: Fix `prefer-fenced-code-blocks` to detect `::` indented code blocks
+
+**Created:** 2026-03-01
+
+## Overview
+
+### Problem Statement
+
+The `prefer-fenced-code-blocks` rule (enrichment check) only detects `>>>` doctest patterns via `_DOCTEST_PATTERN = re.compile(r"^\s*>>>")`. It completely misses reStructuredText `::` indented code blocks in `Examples:` sections.
+
+This is a genuine rendering gap — not a style preference. Research confirmed:
+- **mkdocstrings** only supports rST field lists (`:param:`, `:returns:`), not full rST markup like `::` directives
+- **Material for MkDocs** provides no syntax highlighting, copy button, or annotations for indented code blocks — its code blocks reference is entirely fenced-block oriented
+- **Griffe** recommends fenced code blocks and only auto-parses `>>>` in Examples sections
+
+Result: `::` blocks in docstrings rendered through mkdocs-material + mkdocstrings produce unstyled monospace text with no syntax highlighting, no copy button, and no annotations. The `::` literal may even render as visible text.
+
+Docvet's own codebase has **22 instances** across 13 source files — all inside `Examples:` sections — that pass silently.
+
+### Solution
+
+Extend the existing `_check_prefer_fenced_code_blocks` function with a second regex pattern (`_RST_BLOCK_PATTERN`) and a forward-scan indentation verification helper. Convert all 22 `::` instances in own codebase to fenced code blocks. Update 4 docs pages. Deliver atomically (pre-commit hook `docvet check --staged` enforces all-or-nothing).
+
+### Scope
+
+**In Scope:**
+- Add `_RST_BLOCK_PATTERN` regex and `_has_rst_indented_block` helper to `enrichment.py`
+- Extend `_check_prefer_fenced_code_blocks` to detect `::` alongside `>>>`
+- Emit a distinct Finding message for `::` vs `>>>`
+- Unit tests: positive, negative, edge cases for `::` detection
+- Convert all 22 `::` instances across 13 source files to fenced code blocks (includes `docs/main.py`)
+- Update `_check_prefer_fenced_code_blocks` docstring to mention `::` alongside `>>>`
+- Update 4 docs pages: rule page, rules.yml, enrichment check page, configuration page
+
+**Out of Scope:**
+- New rule creation (extending existing rule)
+- New docs pages (updating existing pages only)
+- `::` detection outside `Examples:` sections (all 22 instances are inside Examples, zero outside)
+- Config schema changes (same rule name, same toggle)
+- Detection of `::` inside fenced code block content (documented limitation)
+
+## Context for Development
+
+### Codebase Patterns
+
+- Table-driven dispatch: `_RULE_DISPATCH` in `enrichment.py:1256+` maps config keys to check functions. No change needed — same function, same entry.
+- Section extraction: `_extract_section_content(symbol.docstring, "Examples")` at `enrichment.py:1232` scopes the scan to `Examples:` content only.
+- Helper extraction pattern: used throughout enrichment.py to keep check function CC under 15 (e.g., `_SYMBOL_KIND_DISPLAY`, `_extract_section_content`).
+- Finding dataclass: all 6 fields (`file`, `line`, `symbol`, `rule`, `message`, `category`) must be populated.
+- Pre-commit constraint: `docvet check --staged` runs on every commit. The rule implementation and all docstring conversions must land together.
+
+### Files to Reference
+
+| File | Purpose |
+| ---- | ------- |
+| `src/docvet/checks/enrichment.py:1195-1252` | Current `_check_prefer_fenced_code_blocks` implementation |
+| `src/docvet/checks/enrichment.py:1112-1117` | `_SYMBOL_KIND_DISPLAY` map (has `"module"` — no change needed) |
+| `src/docvet/checks/enrichment.py:100-132` | `_extract_section_content` — preserves original indentation |
+| `src/docvet/checks/enrichment.py:1256-1275` | `_RULE_DISPATCH` table (no change needed) |
+| `tests/unit/checks/test_enrichment.py:3750-3930` | Existing `_check_prefer_fenced_code_blocks` tests (8 tests) |
+| `tests/unit/checks/test_enrichment.py:262-273` | `_make_symbol_and_index` helper — filters OUT module symbols |
+| `docs/site/rules/prefer-fenced-code-blocks.md` | Rule page: macros + static "What it detects", example tabs |
+| `docs/rules.yml:150-167` | YAML catalog: `summary` + `fix` fields (feed macros) |
+| `docs/site/checks/enrichment.md:22` | Enrichment check page rule table row |
+| `docs/site/configuration.md:129` | Configuration page rule description |
+| `docs/main.py:40-98` | Macros: `rule_header()` renders summary, `rule_fix()` renders fix |
+
+### Technical Decisions
+
+1. **Extend, don't split**: Single rule covers both `>>>` and `::` — same intent (prefer fenced blocks), same config toggle.
+2. **`Examples:` scope only**: All 22 codebase instances are inside `Examples:` sections. Zero instances outside. No practical benefit to expanding.
+3. **Two-step detection for `::` **: Match `line.rstrip().endswith("::")` then verify next non-blank line has greater indentation **relative to the `::` line's own indent** (not absolute column 0). `_extract_section_content` preserves original docstring indentation, so relative comparison is required.
+4. **Helper extraction**: `_has_rst_indented_block(lines, index)` keeps the main check function's CC unchanged.
+5. **Detection order**: Scan for `>>>` first (existing loop), then `::` second. Return on first match — one Finding per symbol. This preserves backward compatibility: any docstring that currently triggers `>>>` detection continues to produce the same Finding.
+6. **Distinct messages**: `::` findings say "uses reStructuredText indented code block (::)" vs existing "uses doctest format (>>>)".
+7. **Language markers for conversions**: CLI examples (`$ docvet ...`) get ```` ```bash ````, Python import/API examples get ```` ```python ````, YAML config snippets get ```` ```yaml ````, Jinja2 template syntax get ```` ```jinja2 ````.
+8. **Module-level symbols supported**: `_SYMBOL_KIND_DISPLAY` has `"module": "module"` entry (`enrichment.py:1116`). Message generation works for all symbol kinds.
+9. **Docs macros pull from YAML**: `rule_header()` renders `rules.yml` `summary` field. `rule_fix()` renders `rules.yml` `fix` field. No hardcoded text in `docs/main.py` macros. Static markdown sections ("What it detects", "Why is this a problem?", example tabs) in the rule page need manual update.
+
+## Implementation Plan
+
+### Tasks
+
+- [ ] Task 1: Add `_RST_BLOCK_PATTERN` regex and `_has_rst_indented_block` helper
+  - File: `src/docvet/checks/enrichment.py`
+  - Action: Add `_RST_BLOCK_PATTERN = re.compile(r"::\s*$")` near `_DOCTEST_PATTERN` (line ~1198). **Use `.search()` (not `.match()`)** for this pattern — unlike `_DOCTEST_PATTERN` which has `^\s*` prefix for `.match()`, `_RST_BLOCK_PATTERN` has no start anchor, so `.match()` would fail on lines with leading text/whitespace. Add `_has_rst_indented_block(lines: list[str], index: int) -> bool` helper that: (a) gets the indent level of `lines[index]` (the `::` line), (b) scans forward from `index + 1` skipping blank lines, (c) returns `True` if the first non-blank line has strictly greater indentation than the `::` line, `False` otherwise (including if no non-blank line follows).
+
+- [ ] Task 2: Extend `_check_prefer_fenced_code_blocks` to detect `::` blocks
+  - File: `src/docvet/checks/enrichment.py`
+  - Action: After the existing `>>>` for-loop (lines 1238-1250), add a second scan: split content into lines, enumerate them, use `_RST_BLOCK_PATTERN.search(line)` to detect `::` (must be `.search()`, not `.match()`), call `_has_rst_indented_block` to confirm. If confirmed, return a Finding with message `f"Examples: section in {kind_display} '{symbol.name}' uses reStructuredText indented code block (::) instead of fenced code blocks"` and `category="recommended"`. Preserve existing behavior: `>>>` detection first, `::` second, return on first match.
+
+- [ ] Task 3: Update `_check_prefer_fenced_code_blocks` docstring
+  - File: `src/docvet/checks/enrichment.py`
+  - Action: Update the function docstring (lines 1208-1225) to mention `::` detection alongside `>>>`. Update the summary line, the description body, and the Returns section to reference both patterns.
+
+- [ ] Task 4: Write unit tests for `::` detection
+  - File: `tests/unit/checks/test_enrichment.py`
+  - Action: Add the following tests after the existing `_check_prefer_fenced_code_blocks` test block (after line ~3930):
+    - `test_fenced_blocks_when_rst_indented_block_returns_finding` — class docstring with `Typical usage::` + indented code in Examples. Assert Finding with `rule="prefer-fenced-code-blocks"`, `category="recommended"`, `"::"` in message.
+    - `test_fenced_blocks_when_rst_no_indented_follow_returns_none` — `::` at end of line but next non-blank line has same or less indentation. Assert `None`. Fixture shape: `Examples:` section with `    Not a code block::` (4-space indent) followed by blank line then `    This is not indented more.` (also 4-space indent). Helper returns `False` because follow-on indent is not strictly greater.
+    - `test_fenced_blocks_when_rst_trailing_whitespace_returns_finding` — `::` followed by trailing spaces (`::   `). Assert Finding fires.
+    - `test_fenced_blocks_when_mixed_doctest_and_rst_returns_doctest_finding` — Examples with `>>>` before `::`. Assert Finding message contains `">>>"` (not `"::"`), confirming `>>>` takes precedence.
+    - `test_fenced_blocks_when_module_rst_block_returns_finding` — Module-level docstring with `::` block. Use inline `[s for s in symbols if s.kind == "module"][0]` pattern. Assert Finding with `"module"` in message.
+    - `test_fenced_blocks_when_bare_double_colon_line_with_indent_returns_finding` — Bare `::` on its own line followed by indented code. Assert Finding fires.
+    - `test_fenced_blocks_when_rst_block_config_disabled_returns_no_finding` — Full orchestrator test with `prefer_fenced_code_blocks=False` and `::` block. Assert zero findings for this rule.
+    - `test_fenced_blocks_when_rst_block_orchestrator_fires_when_enabled` — Full orchestrator test with `prefer_fenced_code_blocks=True` and `::` block. Assert exactly 1 finding.
+
+- [ ] Task 5: Convert `::` docstrings in source files (13 files, 22 instances)
+  - Files: `src/docvet/__init__.py` (2), `src/docvet/ast_utils.py` (1), `src/docvet/cli.py` (3), `src/docvet/config.py` (1), `src/docvet/discovery.py` (2), `src/docvet/lsp.py` (3), `src/docvet/reporting.py` (3), `src/docvet/checks/_finding.py` (1), `src/docvet/checks/coverage.py` (1), `src/docvet/checks/enrichment.py` (1), `src/docvet/checks/freshness.py` (1), `src/docvet/checks/griffe_compat.py` (1), `docs/main.py` (2)
+  - Action: For each `::` instance: (a) remove `::` from the directive line (e.g., `Run all checks on changed files::` becomes `Run all checks on changed files:`), (b) replace the indented block with a fenced code block using the appropriate language marker — `bash` for CLI examples (`$ docvet ...`), `python` for import/API examples, `yaml` for YAML config snippets, `jinja2` for Jinja2 template syntax (e.g., `docs/main.py` line 13). (c) Verify indentation is consistent with surrounding docstring.
+
+- [ ] Task 6: Update `docs/rules.yml`
+  - File: `docs/rules.yml`
+  - Action: Update line 155 `summary` to: `Examples section uses doctest (>>>) or reStructuredText (::) indented code blocks instead of fenced code blocks`. Update `fix` field (lines 157-166) to mention both `>>>` and `::` patterns with fix guidance for each.
+
+- [ ] Task 7: Update rule reference page
+  - File: `docs/site/rules/prefer-fenced-code-blocks.md`
+  - Action: (a) Update "What it detects" to mention `::` alongside `>>>`. (b) Update "Why is this a problem?" if needed. (c) Add a second Violation/Fix example tab pair showing `::` indented block (Violation) converted to fenced block (Fix).
+
+- [ ] Task 8: Update enrichment check page and configuration page
+  - Files: `docs/site/checks/enrichment.md`, `docs/site/configuration.md`
+  - Action: Update rule description in the table row (enrichment.md line 22, configuration.md line 129) to mention `::` alongside `>>>`.
+
+- [ ] Task 9: Validate
+  - Action: (a) Run `uv run pytest` — all tests pass. (b) Run `uv run ruff check .` and `uv run ruff format .` — no issues. (c) Run `docvet check --all` — zero findings (all `src/` `::` instances converted). (d) Run `docvet enrichment docs/main.py` — zero findings (`docs/main.py` is outside `src/` and not covered by `--all` discovery). (e) Run `mkdocs build --strict` — docs build clean. (f) Run `uv run ty check` — no type errors.
+
+### Acceptance Criteria
+
+- [ ] AC 1: Given a class docstring with an `Examples:` section containing `Typical usage::` followed by an indented code block, when `_check_prefer_fenced_code_blocks` runs, then a Finding is returned with `rule="prefer-fenced-code-blocks"`, `category="recommended"`, and `"::"` in the message.
+
+- [ ] AC 2: Given a class docstring with an `Examples:` section containing `::` at end of line but the next non-blank line has equal or less indentation, when `_check_prefer_fenced_code_blocks` runs, then `None` is returned (no false positive).
+
+- [ ] AC 3: Given a module-level docstring with an `Examples:` section containing `::` followed by an indented code block, when `_check_prefer_fenced_code_blocks` runs, then a Finding is returned with `"module"` in the message.
+
+- [ ] AC 4: Given a docstring with both `>>>` and `::` patterns in the `Examples:` section (with `>>>` appearing first), when `_check_prefer_fenced_code_blocks` runs, then the Finding message contains `">>>"` and not `"::"` (precedence preserved).
+
+- [ ] AC 5: Given `EnrichmentConfig(prefer_fenced_code_blocks=False)` and a docstring with `::` indented blocks, when `check_enrichment` runs, then zero findings with `rule="prefer-fenced-code-blocks"` are returned.
+
+- [ ] AC 6: Given the docvet codebase with all 22 `::` instances converted to fenced code blocks, when `docvet check --all` runs, then zero `prefer-fenced-code-blocks` findings are reported.
+
+- [ ] AC 7: Given the updated docs pages, when `mkdocs build --strict` runs, then the build succeeds with no warnings.
+
+## Additional Context
+
+### Dependencies
+
+- No new dependencies. Regex and string operations only (stdlib).
+- No config schema changes — existing `prefer-fenced-code-blocks` bool toggle covers both patterns.
+
+### Testing Strategy
+
+- **Unit tests (positive)**: Fixture with `::` + indented block inside `Examples:` section, assert Finding emitted with correct rule, message, and category.
+- **Unit tests (negative)**: `::` at end of line followed by non-indented line — must NOT fire.
+- **Unit tests (edge cases)**: `::` with trailing whitespace, bare `::` on own line, mixed `>>>` and `::` in same docstring (assert `>>>` fires first), `::` preceded by text (`Typical usage::`).
+- **Unit tests (module-level)**: Module-level docstring with `::` block, using established inline pattern `[s for s in symbols if s.kind == "module"][0]`. Assert Finding message includes "module" kind display.
+- **Dogfood validation**: After fix, `docvet enrichment --all` must fire on own codebase (pre-conversion) and produce zero findings (post-conversion).
+- **Docs validation**: `mkdocs build --strict` passes after docs updates.
+
+### Gaps Identified and Resolved (Step 2)
+
+| # | Gap | Resolution |
+|---|-----|-----------|
+| 1 | Indentation comparison | Relative to `::` line's indent, not absolute. Specified in Technical Decision #3. |
+| 2 | Detection order | `>>>` first, `::` second, return first match. Specified in Technical Decision #5. |
+| 3 | Module-level test fixture | No new helper needed. Inline `[s for s in symbols if s.kind == "module"][0]` pattern used 20+ times in test file. |
+| 4 | `_SYMBOL_KIND_DISPLAY` for module | Confirmed: `"module": "module"` at `enrichment.py:1116`. |
+| 5 | Macro tracing | `rule_header()` and `rule_fix()` both pull from `rules.yml` — no hardcoded text. Static sections in rule `.md` need manual update. |
+| 6 | Frontmatter duplicate | Fixed in Step 1 revision. |
+
+### Notes
+
+**High-Risk Items:**
+- Docstring conversions (Task 5) are the highest-risk task — 22 manual edits across 13 files where incorrect indentation or wrong language marker could break docstring parsing or rendered output. Mitigated by dogfood validation (Task 9c) and docs build (Task 9d).
+- CC budget: the helper extraction (Task 1) is designed to keep `_check_prefer_fenced_code_blocks` CC unchanged. Verify with `analyze_code_snippet` after Task 2.
+
+**Known Limitations:**
+- `::` inside a fenced code block's content would false-positive if it appears in `Examples:` section text (documented out-of-scope — same behavior as existing `>>>` inside fenced blocks per test at line 3908).
+- Rule only scans `Examples:` sections. `::` in other docstring sections (Args preamble, module description) is not detected. All 22 known instances are in `Examples:` so this is acceptable.
+- **`>>>` masks `::` detection**: If a docstring's `Examples:` section contains both `>>>` and `::` patterns, only `>>>` is reported (detection order per Technical Decision #5). A `::` block in the same section will not be flagged until the `>>>` is fixed. This is by design to preserve backward compatibility, but users may be surprised if they fix `>>>` and a new `::` finding appears.
+
+**References:**
+- GitHub Issue: #225
+- Party mode consensus: four sessions confirmed approach, scope, delivery constraint, and identified + resolved 6 gaps
+- Research sources: Griffe docs, mkdocstrings#278, Material for MkDocs code blocks reference, mkdocs#282
+- Pre-commit makes this atomic — rule impl + all 22 docstring conversions + docs updates must land in one PR

--- a/docs/main.py
+++ b/docs/main.py
@@ -4,16 +4,20 @@ Loads rule metadata from docs/rules.yml and provides Jinja macros
 for rendering consistent rule page headers and fix guidance sections.
 
 Examples:
-    Configure in ``mkdocs.yml``::
+    Configure in ``mkdocs.yml``:
 
-        plugins:
-          - macros:
-              module_name: docs/main
+    ```yaml
+    plugins:
+      - macros:
+          module_name: docs/main
+    ```
 
-    Use in a rule page::
+    Use in a rule page:
 
-        {{rule_header()}}
-        {{rule_fix()}}
+    ```jinja2
+    {{rule_header()}}
+    {{rule_fix()}}
+    ```
 
 See Also:
     :doc:`docs/rules.yml`: Rule metadata catalog consumed by this module.

--- a/docs/rules.yml
+++ b/docs/rules.yml
@@ -152,16 +152,29 @@
   check: enrichment
   category: recommended
   applies_to: any symbol
-  summary: Examples section uses doctest format instead of fenced code blocks
+  summary: Examples section uses doctest (`>>>`) or reStructuredText (`::`) indented code blocks instead of fenced code blocks
   since: "1.0.0"
   fix: |
-    Replace doctest `>>>` format with triple-backtick fenced code blocks and a `python` language marker:
+    Replace doctest `>>>` format or rST `::` indented blocks with triple-backtick fenced code blocks and a language marker:
+
+    **Doctest `>>>` format:**
 
     ```python
     Examples:
         ```python
         add(1, 2)  # returns 3
         add(-1, 1)  # returns 0
+        ```
+    ```
+
+    **rST `::` indented block** — remove `::` from the directive line and wrap the code in fenced backticks:
+
+    ```python
+    Examples:
+        Run the check:
+
+        ```bash
+        $ docvet check --all
         ```
     ```
 

--- a/docs/site/checks/enrichment.md
+++ b/docs/site/checks/enrichment.md
@@ -19,7 +19,7 @@ docvet enrichment --all
 | [`missing-typed-attributes`](../rules/missing-typed-attributes.md) | recommended | classes | `Attributes:` section entries lack typed format `name (type): description` |
 | [`missing-examples`](../rules/missing-examples.md) | recommended | classes, modules | Symbol kind in `require-examples` list lacks `Examples:` section |
 | [`missing-cross-references`](../rules/missing-cross-references.md) | recommended | modules | Module missing or malformed `See Also:` section |
-| [`prefer-fenced-code-blocks`](../rules/prefer-fenced-code-blocks.md) | recommended | any symbol | `Examples:` section uses doctest `>>>` instead of fenced code blocks |
+| [`prefer-fenced-code-blocks`](../rules/prefer-fenced-code-blocks.md) | recommended | any symbol | `Examples:` section uses doctest `>>>` or rST `::` instead of fenced code blocks |
 
 **Required** rules flag structural gaps where the docstring is objectively incomplete. **Recommended** rules flag best-practice improvements that enhance documentation quality.
 

--- a/docs/site/configuration.md
+++ b/docs/site/configuration.md
@@ -126,7 +126,7 @@ These keys go under `[tool.docvet.enrichment]`:
 | `require-attributes` | `bool` | `true` | Require `Attributes:` sections on classes and modules |
 | `require-typed-attributes` | `bool` | `true` | Require typed format in `Attributes:` entries |
 | `require-cross-references` | `bool` | `true` | Require `See Also:` in module docstrings |
-| `prefer-fenced-code-blocks` | `bool` | `true` | Prefer fenced code blocks over doctest `>>>` format |
+| `prefer-fenced-code-blocks` | `bool` | `true` | Prefer fenced code blocks over doctest `>>>` and rST `::` formats |
 | `require-examples` | `list[str]` | `["class", "protocol", "dataclass", "enum"]` | Symbol kinds requiring `Examples:` sections |
 
 ### Example

--- a/docs/site/rules/prefer-fenced-code-blocks.md
+++ b/docs/site/rules/prefer-fenced-code-blocks.md
@@ -4,15 +4,17 @@
 
 ## What it detects
 
-This rule flags `Examples:` sections that use doctest `>>>` format instead of triple-backtick fenced code blocks with a `python` language marker.
+This rule flags `Examples:` sections that use doctest `>>>` format or reStructuredText `::` indented code blocks instead of triple-backtick fenced code blocks with a language marker.
 
 ## Why is this a problem?
 
-mkdocs-material renders fenced code blocks with syntax highlighting, copy buttons, and line numbers. Doctest `>>>` format renders as plain, unhighlighted text, resulting in a noticeably worse reading experience on your documentation site. Fenced blocks also support annotations and other material theme features.
+mkdocs-material renders fenced code blocks with syntax highlighting, copy buttons, and line numbers. Doctest `>>>` format and rST `::` indented blocks render as plain, unhighlighted text with no copy button or annotations, resulting in a noticeably worse reading experience on your documentation site. The `::` literal may even render as visible text.
 
 {{ rule_fix() }}
 
-## Example
+## Examples
+
+### Doctest `>>>` format
 
 === "Violation"
 
@@ -56,4 +58,32 @@ mkdocs-material renders fenced code blocks with syntax highlighting, copy button
             ```
         """
         return a + b
+    ```
+
+### rST `::` indented block
+
+=== "Violation"
+
+    ```python
+    """Module for data processing.
+
+    Examples:
+        Run the processing pipeline::
+
+            $ docvet check --all
+    """
+    ```
+
+=== "Fix"
+
+    ```python hl_lines="4 5 6 7"
+    """Module for data processing.
+
+    Examples:
+        Run the processing pipeline:
+
+        ```bash
+        $ docvet check --all
+        ```
+    """
     ```

--- a/src/docvet/__init__.py
+++ b/src/docvet/__init__.py
@@ -8,13 +8,17 @@ Attributes:
     Finding: Re-exported from ``docvet.checks`` for convenience.
 
 Examples:
-    Run all checks on changed files::
+    Run all checks on changed files:
 
-        $ docvet check
+    ```bash
+    $ docvet check
+    ```
 
-    Run all checks on the entire codebase::
+    Run all checks on the entire codebase:
 
-        $ docvet check --all
+    ```bash
+    $ docvet check --all
+    ```
 
 See Also:
     [`docvet.checks`][]: Check modules and the Finding dataclass.

--- a/src/docvet/ast_utils.py
+++ b/src/docvet/ast_utils.py
@@ -6,12 +6,14 @@ Used by the enrichment and freshness check modules to map source
 locations to semantic symbols.
 
 Examples:
-    Extract documented symbols from a source file::
+    Extract documented symbols from a source file:
 
-        from docvet.ast_utils import get_documented_symbols
+    ```python
+    from docvet.ast_utils import get_documented_symbols
 
-        tree = ast.parse(source)
-        symbols = get_documented_symbols(tree)
+    tree = ast.parse(source)
+    symbols = get_documented_symbols(tree)
+    ```
 
 See Also:
     [`docvet.checks.enrichment`][]: Enrichment rules that consume symbols.

--- a/src/docvet/checks/_finding.py
+++ b/src/docvet/checks/_finding.py
@@ -6,9 +6,11 @@ Finding instances).  External consumers should import Finding from
 ``docvet.checks``, not from this module.
 
 Examples:
-    Import ``Finding`` through the public API::
+    Import ``Finding`` through the public API:
 
-        from docvet.checks import Finding
+    ```python
+    from docvet.checks import Finding
+    ```
 
 See Also:
     [`docvet.checks`][]: Public re-export surface for ``Finding``.

--- a/src/docvet/checks/coverage.py
+++ b/src/docvet/checks/coverage.py
@@ -6,11 +6,13 @@ generation.  Uses pure filesystem checks via ``pathlib`` — no AST,
 no git, no external dependencies.
 
 Examples:
-    Run the coverage check on a list of files::
+    Run the coverage check on a list of files:
 
-        from docvet.checks import check_coverage
+    ```python
+    from docvet.checks import check_coverage
 
-        findings = check_coverage(file_paths, src_root=Path("src"))
+    findings = check_coverage(file_paths, src_root=Path("src"))
+    ```
 
 See Also:
     [`docvet.checks`][]: Package-level re-exports.

--- a/src/docvet/checks/enrichment.py
+++ b/src/docvet/checks/enrichment.py
@@ -6,12 +6,14 @@ analysis with section header parsing. Implements Layer 3 of the docstring
 quality model.
 
 Examples:
-    Run the enrichment check on a source file::
+    Run the enrichment check on a source file:
 
-        from docvet.checks import check_enrichment
-        from docvet.config import EnrichmentConfig
+    ```python
+    from docvet.checks import check_enrichment
+    from docvet.config import EnrichmentConfig
 
-        findings = check_enrichment(source, tree, EnrichmentConfig(), "app.py")
+    findings = check_enrichment(source, tree, EnrichmentConfig(), "app.py")
+    ```
 
 See Also:
     [`docvet.config`][]: ``EnrichmentConfig`` dataclass for rule toggles.
@@ -1196,6 +1198,31 @@ def _check_missing_cross_references(
 # ---------------------------------------------------------------------------
 
 _DOCTEST_PATTERN = re.compile(r"^\s*>>>")
+_RST_BLOCK_PATTERN = re.compile(r"::\s*$")
+
+
+def _has_rst_indented_block(lines: list[str], index: int) -> bool:
+    """Check whether the ``::`` line at *index* is followed by an indented block.
+
+    Determines if the line ending with ``::`` introduces a
+    reStructuredText indented code block by verifying that the first
+    non-blank line after ``index`` has strictly greater indentation
+    than the ``::`` line itself.
+
+    Args:
+        lines: All lines from the ``Examples:`` section content.
+        index: Index of the line ending with ``::``.
+
+    Returns:
+        ``True`` when a non-blank line with greater indentation follows,
+        ``False`` otherwise (including when no non-blank line follows).
+    """
+    rst_indent = len(lines[index]) - len(lines[index].lstrip())
+    for subsequent in lines[index + 1 :]:
+        if not subsequent.strip():
+            continue
+        return (len(subsequent) - len(subsequent.lstrip())) > rst_indent
+    return False
 
 
 def _check_prefer_fenced_code_blocks(
@@ -1205,11 +1232,14 @@ def _check_prefer_fenced_code_blocks(
     config: EnrichmentConfig,
     file_path: str,
 ) -> Finding | None:
-    """Detect ``Examples:`` sections using doctest format instead of fenced blocks.
+    """Detect ``Examples:`` sections using non-fenced code block formats.
 
-    Checks for ``>>>`` patterns in the ``Examples:`` section content.
-    Only applies when the ``Examples:`` section exists — absence is
-    handled by the ``missing-examples`` rule.
+    Checks for ``>>>`` doctest patterns and ``::`` reStructuredText
+    indented code blocks in the ``Examples:`` section content.  The
+    ``>>>`` scan runs first; ``::`` detection fires only when no
+    doctest pattern is found.  Only applies when the ``Examples:``
+    section exists — absence is handled by the ``missing-examples``
+    rule.
 
     Args:
         symbol: The documented symbol to inspect.
@@ -1221,7 +1251,8 @@ def _check_prefer_fenced_code_blocks(
 
     Returns:
         A ``Finding`` with ``rule="prefer-fenced-code-blocks"`` when
-        doctest format is found, or ``None`` otherwise.
+        doctest format (``>>>``) or an rST indented code block (``::``)
+        is found, or ``None`` otherwise.
     """
     if "Examples" not in sections:
         return None
@@ -1235,7 +1266,9 @@ def _check_prefer_fenced_code_blocks(
 
     kind_display = _SYMBOL_KIND_DISPLAY.get(symbol.kind, symbol.kind)
 
-    for line in content.splitlines():
+    lines = content.splitlines()
+
+    for line in lines:
         if _DOCTEST_PATTERN.match(line):
             return Finding(
                 file=file_path,
@@ -1245,6 +1278,21 @@ def _check_prefer_fenced_code_blocks(
                 message=(
                     f"Examples: section in {kind_display} '{symbol.name}' "
                     f"uses doctest format (>>>) instead of fenced code blocks"
+                ),
+                category="recommended",
+            )
+
+    for i, line in enumerate(lines):
+        if _RST_BLOCK_PATTERN.search(line) and _has_rst_indented_block(lines, i):
+            return Finding(
+                file=file_path,
+                line=symbol.line,
+                symbol=symbol.name,
+                rule="prefer-fenced-code-blocks",
+                message=(
+                    f"Examples: section in {kind_display} '{symbol.name}' "
+                    f"uses reStructuredText indented code block (::) "
+                    f"instead of fenced code blocks"
                 ),
                 category="recommended",
             )

--- a/src/docvet/checks/freshness.py
+++ b/src/docvet/checks/freshness.py
@@ -5,11 +5,13 @@ git diff hunks to AST symbols; drift mode uses git blame age comparison.
 Implements Layer 4 of the docstring quality model.
 
 Examples:
-    Run the freshness diff check on a file::
+    Run the freshness diff check on a file:
 
-        from docvet.checks import check_freshness_diff
+    ```python
+    from docvet.checks import check_freshness_diff
 
-        findings = check_freshness_diff(path, diff_text, tree)
+    findings = check_freshness_diff(path, diff_text, tree)
+    ```
 
 See Also:
     [`docvet.config`][]: ``FreshnessConfig`` dataclass for drift thresholds.

--- a/src/docvet/checks/griffe_compat.py
+++ b/src/docvet/checks/griffe_compat.py
@@ -5,11 +5,13 @@ parameter/type mismatches and formatting issues that would cause rendering
 problems in mkdocs-material + mkdocstrings documentation.
 
 Examples:
-    Run the griffe compatibility check on a list of files::
+    Run the griffe compatibility check on a list of files:
 
-        from docvet.checks import check_griffe_compat
+    ```python
+    from docvet.checks import check_griffe_compat
 
-        findings = check_griffe_compat(file_paths)
+    findings = check_griffe_compat(file_paths)
+    ```
 
 See Also:
     [`docvet.checks`][]: Package-level re-exports.

--- a/src/docvet/cli.py
+++ b/src/docvet/cli.py
@@ -12,17 +12,23 @@ Output formatting is delegated to :func:`_emit_findings`, which
 dispatches to the appropriate formatter in :mod:`docvet.reporting`.
 
 Examples:
-    Run all checks on changed files::
+    Run all checks on changed files:
 
-        $ docvet check
+    ```bash
+    $ docvet check
+    ```
 
-    Check specific files::
+    Check specific files:
 
-        $ docvet check src/foo.py src/bar.py
+    ```bash
+    $ docvet check src/foo.py src/bar.py
+    ```
 
-    Run the enrichment check on the entire codebase::
+    Run the enrichment check on the entire codebase:
 
-        $ docvet enrichment --all
+    ```bash
+    $ docvet enrichment --all
+    ```
 
 See Also:
     [`docvet.checks`][]: Public API re-exports for check functions.

--- a/src/docvet/config.py
+++ b/src/docvet/config.py
@@ -9,12 +9,14 @@ composable validation helpers (``_validate_string_list``,
 defaults for all check modules.
 
 Examples:
-    Load configuration from the project root::
+    Load configuration from the project root:
 
-        from docvet.config import load_config
+    ```python
+    from docvet.config import load_config
 
-        config = load_config()
-        enrichment = config.enrichment
+    config = load_config()
+    enrichment = config.enrichment
+    ```
 
 See Also:
     [`docvet.cli`][]: CLI entry point that loads config on startup.

--- a/src/docvet/discovery.py
+++ b/src/docvet/discovery.py
@@ -13,13 +13,17 @@ path-level ``fnmatch`` patterns (``scripts/gen_*.py``), and
 component-level patterns (``tests``).
 
 Examples:
-    Discover staged files via the CLI::
+    Discover staged files via the CLI:
 
-        $ docvet check --staged
+    ```bash
+    $ docvet check --staged
+    ```
 
-    Discover the full codebase::
+    Discover the full codebase:
 
-        $ docvet check --all
+    ```bash
+    $ docvet check --all
+    ```
 
 See Also:
     [`docvet.cli`][]: Subcommands that invoke discovery.

--- a/src/docvet/lsp.py
+++ b/src/docvet/lsp.py
@@ -17,13 +17,17 @@ Attributes:
     server: The pygls ``LanguageServer`` instance.
 
 Examples:
-    Start the server on stdio (typically invoked by an editor)::
+    Start the server on stdio (typically invoked by an editor):
 
-        $ docvet lsp
+    ```bash
+    $ docvet lsp
+    ```
 
-    Install with the ``[lsp]`` extra::
+    Install with the ``[lsp]`` extra:
 
-        $ pip install docvet[lsp]
+    ```bash
+    $ pip install docvet[lsp]
+    ```
 
 See Also:
     [`docvet.checks`][]: Check modules that produce Finding objects.
@@ -262,11 +266,13 @@ def start_server() -> None:
     then starts the pygls server in stdio mode.
 
     Examples:
-        Typically invoked by the ``docvet lsp`` CLI command::
+        Typically invoked by the ``docvet lsp`` CLI command:
 
-            from docvet.lsp import start_server
+        ```python
+        from docvet.lsp import start_server
 
-            start_server()
+        start_server()
+        ```
     """
     server.docvet_config = load_config()  # type: ignore[attr-defined]
     server.start_io()

--- a/src/docvet/reporting.py
+++ b/src/docvet/reporting.py
@@ -6,17 +6,23 @@ summary line for stderr, groups findings by file, calculates summary
 statistics, and determines the CLI exit code based on finding severity.
 
 Examples:
-    Generate a terminal report via the CLI::
+    Generate a terminal report via the CLI:
 
-        $ docvet check --all
+    ```bash
+    $ docvet check --all
+    ```
 
-    Write a markdown report to a file::
+    Write a markdown report to a file:
 
-        $ docvet check --all --format markdown --output report.md
+    ```bash
+    $ docvet check --all --format markdown --output report.md
+    ```
 
-    Produce JSON output for agent or CI consumption::
+    Produce JSON output for agent or CI consumption:
 
-        $ docvet check --all --format json
+    ```bash
+    $ docvet check --all --format json
+    ```
 
 See Also:
     [`docvet.cli`][]: Subcommands that invoke report rendering.

--- a/tests/fixtures/complete_module.py
+++ b/tests/fixtures/complete_module.py
@@ -1,9 +1,11 @@
 """Fixture: fully complete docstrings — no findings expected.
 
 Examples:
-    Used by the test suite to verify zero-finding output::
+    Used by the test suite to verify zero-finding output:
 
-        source = Path("tests/fixtures/complete_module.py").read_text()
+    ```python
+    source = Path("tests/fixtures/complete_module.py").read_text()
+    ```
 
 See Also:
     [`tests.fixtures`][]: Other test fixture modules.

--- a/tests/fixtures/missing_raises.py
+++ b/tests/fixtures/missing_raises.py
@@ -1,9 +1,11 @@
 """Fixture: function raises but docstring has no Raises section.
 
 Examples:
-    Used by the test suite to verify missing-raises detection::
+    Used by the test suite to verify missing-raises detection:
 
-        source = Path("tests/fixtures/missing_raises.py").read_text()
+    ```python
+    source = Path("tests/fixtures/missing_raises.py").read_text()
+    ```
 
 See Also:
     [`tests.fixtures`][]: Other test fixture modules.

--- a/tests/fixtures/missing_yields.py
+++ b/tests/fixtures/missing_yields.py
@@ -1,9 +1,11 @@
 """Fixture: generator yields but docstring has no Yields section.
 
 Examples:
-    Used by the test suite to verify missing-yields detection::
+    Used by the test suite to verify missing-yields detection:
 
-        source = Path("tests/fixtures/missing_yields.py").read_text()
+    ```python
+    source = Path("tests/fixtures/missing_yields.py").read_text()
+    ```
 
 See Also:
     [`tests.fixtures`][]: Other test fixture modules.

--- a/tests/unit/checks/test_enrichment.py
+++ b/tests/unit/checks/test_enrichment.py
@@ -3928,3 +3928,207 @@ class Foo:
     # Per dev notes edge case 13: fire anyway even if >>> is in fenced block
     assert result is not None
     assert result.rule == "prefer-fenced-code-blocks"
+
+
+# --- :: (rST indented block) detection tests ---
+
+
+def test_fenced_blocks_when_rst_indented_block_returns_finding():
+    source = '''\
+class Foo:
+    """A class.
+
+    Examples:
+        Typical usage::
+
+            foo = Foo()
+            print(foo)
+    """
+    pass
+'''
+    symbol, node_index, _ = _make_symbol_and_index(source)
+    sections = _parse_sections(symbol.docstring)
+    config = EnrichmentConfig()
+
+    result = _check_prefer_fenced_code_blocks(
+        symbol, sections, node_index, config, "test.py"
+    )
+
+    assert result is not None
+    assert isinstance(result, Finding)
+    assert result.rule == "prefer-fenced-code-blocks"
+    assert result.category == "recommended"
+    assert "::" in result.message
+    assert "reStructuredText" in result.message
+
+
+def test_fenced_blocks_when_rst_no_indented_follow_returns_none():
+    source = '''\
+class Foo:
+    """A class.
+
+    Examples:
+        Not a code block::
+
+        This is not indented more.
+    """
+    pass
+'''
+    symbol, node_index, _ = _make_symbol_and_index(source)
+    sections = _parse_sections(symbol.docstring)
+    config = EnrichmentConfig()
+
+    result = _check_prefer_fenced_code_blocks(
+        symbol, sections, node_index, config, "test.py"
+    )
+
+    assert result is None
+
+
+def test_fenced_blocks_when_rst_trailing_whitespace_returns_finding():
+    source = '''\
+class Foo:
+    """A class.
+
+    Examples:
+        Typical usage::   \n\n            foo = Foo()
+    """
+    pass
+'''
+    symbol, node_index, _ = _make_symbol_and_index(source)
+    sections = _parse_sections(symbol.docstring)
+    config = EnrichmentConfig()
+
+    result = _check_prefer_fenced_code_blocks(
+        symbol, sections, node_index, config, "test.py"
+    )
+
+    assert result is not None
+    assert result.rule == "prefer-fenced-code-blocks"
+    assert "::" in result.message
+
+
+def test_fenced_blocks_when_mixed_doctest_and_rst_returns_doctest_finding():
+    source = '''\
+class Foo:
+    """A class.
+
+    Examples:
+        >>> foo = Foo()
+
+        Another example::
+
+            print(foo)
+    """
+    pass
+'''
+    symbol, node_index, _ = _make_symbol_and_index(source)
+    sections = _parse_sections(symbol.docstring)
+    config = EnrichmentConfig()
+
+    result = _check_prefer_fenced_code_blocks(
+        symbol, sections, node_index, config, "test.py"
+    )
+
+    assert result is not None
+    assert ">>>" in result.message
+    assert "::" not in result.message
+
+
+def test_fenced_blocks_when_module_rst_block_returns_finding():
+    source = '''\
+"""A module.
+
+Examples:
+    Typical usage::
+
+        import foo
+        foo.bar()
+"""
+'''
+    from docvet.ast_utils import get_documented_symbols
+
+    tree = ast.parse(source)
+    symbols = get_documented_symbols(tree)
+    node_index = _build_node_index(tree)
+    symbol = [s for s in symbols if s.kind == "module"][0]
+    assert symbol.docstring is not None
+    sections = _parse_sections(symbol.docstring)
+    config = EnrichmentConfig()
+
+    result = _check_prefer_fenced_code_blocks(
+        symbol, sections, node_index, config, "test.py"
+    )
+
+    assert result is not None
+    assert result.rule == "prefer-fenced-code-blocks"
+    assert "module" in result.message
+    assert "::" in result.message
+
+
+def test_fenced_blocks_when_bare_double_colon_line_with_indent_returns_finding():
+    source = '''\
+class Foo:
+    """A class.
+
+    Examples:
+        ::
+
+            foo = Foo()
+    """
+    pass
+'''
+    symbol, node_index, _ = _make_symbol_and_index(source)
+    sections = _parse_sections(symbol.docstring)
+    config = EnrichmentConfig()
+
+    result = _check_prefer_fenced_code_blocks(
+        symbol, sections, node_index, config, "test.py"
+    )
+
+    assert result is not None
+    assert result.rule == "prefer-fenced-code-blocks"
+    assert "::" in result.message
+
+
+def test_fenced_blocks_when_rst_block_config_disabled_returns_no_finding():
+    source = '''\
+class Foo:
+    """A class.
+
+    Examples:
+        Typical usage::
+
+            foo = Foo()
+    """
+    pass
+'''
+    tree = ast.parse(source)
+    config = EnrichmentConfig(prefer_fenced_code_blocks=False)
+
+    findings = check_enrichment(source, tree, config, "test.py")
+
+    fenced_findings = [f for f in findings if f.rule == "prefer-fenced-code-blocks"]
+    assert fenced_findings == []
+
+
+def test_fenced_blocks_when_rst_block_orchestrator_fires_when_enabled():
+    source = '''\
+class Foo:
+    """A class.
+
+    Examples:
+        Typical usage::
+
+            foo = Foo()
+    """
+    pass
+'''
+    tree = ast.parse(source)
+    config = EnrichmentConfig(prefer_fenced_code_blocks=True)
+
+    findings = check_enrichment(source, tree, config, "test.py")
+
+    fenced_findings = [f for f in findings if f.rule == "prefer-fenced-code-blocks"]
+    assert len(fenced_findings) == 1
+    assert fenced_findings[0].symbol == "Foo"


### PR DESCRIPTION
The `prefer-fenced-code-blocks` rule only detected doctest `>>>` patterns, completely missing reStructuredText `::` indented code blocks in `Examples:` sections. These `::` blocks render as unstyled monospace text in mkdocs-material with no syntax highlighting, copy button, or annotations — the `::` literal may even render as visible text.

- Add `_RST_BLOCK_PATTERN` regex and `_has_rst_indented_block` forward-scan helper to `enrichment.py`
- Extend `_check_prefer_fenced_code_blocks` to scan for `::` after `>>>` (precedence preserved)
- Convert all 25 `::` indented blocks to fenced code blocks across 16 files (src, docs, test fixtures)
- Add 8 unit tests covering positive, negative, edge, module-level, and orchestrator cases
- Update 4 docs pages (rules.yml, rule page, enrichment check page, configuration page)

Test: `uv run pytest -v`

Closes #225

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- `_has_rst_indented_block` helper uses relative indentation comparison (not absolute) since `_extract_section_content` preserves original docstring indentation
- Detection order: `>>>` first, `::` second — existing findings unchanged (backward compatible)
- Docstring conversions use appropriate language markers (`bash`, `python`, `yaml`, `jinja2`)

### Related
- Issue #225