### PR TITLE
fix(ci): add TestPyPI staging to publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,33 @@
 name: Publish to PyPI
 
+# Triggered when release-please (or manual) creates a version tag.
+# Requires RELEASE_PLEASE_TOKEN (PAT with repo scope) in release-please.yml —
+# tags created by GITHUB_TOKEN do NOT trigger other workflows.
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
+
+# Least-privilege: read-only by default; publish jobs escalate per-job.
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ github.ref_name }}
+  cancel-in-progress: false # never cancel an in-flight publish
 
 jobs:
-  build-and-publish:
+  # ---------------------------------------------------------------------------
+  # Build — produce sdist + wheel, validate contents, upload as artifact.
+  # ---------------------------------------------------------------------------
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-      attestations: write
-    environment: pypi
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Build package
         run: uv build --no-sources
@@ -51,42 +63,114 @@ jobs:
           fi
           echo "Version ${TAG_VERSION} matches — OK"
 
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+      - run: uv cache prune --ci
+        if: always()
+        continue-on-error: true
+
+  # ---------------------------------------------------------------------------
+  # Publish to TestPyPI — validates the package on the staging index first.
+  # Uses OIDC trusted publishing (no stored tokens).
+  # ---------------------------------------------------------------------------
+  publish-testpypi:
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: testpypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: astral-sh/setup-uv@v7
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        run: uv publish --trusted-publishing always --check-url https://test.pypi.org/simple/
+        env:
+          UV_PUBLISH_URL: "https://test.pypi.org/legacy/"
+
+  # ---------------------------------------------------------------------------
+  # Smoke test — install from TestPyPI and verify the package works.
+  # Catches packaging mistakes before they reach production PyPI.
+  # ---------------------------------------------------------------------------
+  smoke-test:
+    needs: [publish-testpypi]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: astral-sh/setup-uv@v7
+      - run: uv python install 3.12
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for TestPyPI index
+        run: sleep 30
+
+      - name: Create virtual environment
+        run: uv venv
+
+      - name: Install from TestPyPI
+        run: |
+          uv pip install \
+            --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            --index-strategy unsafe-best-match \
+            --refresh \
+            "docvet==${{ steps.version.outputs.version }}"
+
+      - name: Verify docvet --version
+        run: uv run --no-project docvet --version
+
+      - name: Verify docvet check --help
+        run: uv run --no-project docvet check --help
+
+  # ---------------------------------------------------------------------------
+  # Publish to PyPI — production release.
+  # Uses OIDC trusted publishing (no stored tokens).
+  # ---------------------------------------------------------------------------
+  publish-pypi:
+    needs: [smoke-test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+    steps:
+      - uses: astral-sh/setup-uv@v7
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
       - name: Publish to PyPI
-        run: uv publish
+        run: uv publish --trusted-publishing always --check-url https://pypi.org/simple/
 
       - name: Attest build provenance
         uses: astral-sh/attest-action@v0.0.5
         with:
           files: dist/*
 
-  smoke-test:
-    runs-on: ubuntu-latest
-    needs: [build-and-publish]
-    timeout-minutes: 5
-    steps:
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for PyPI propagation
-        run: sleep 60
-
-      - name: Install docvet from PyPI
-        run: python -m pip install --no-cache-dir docvet==${{ steps.version.outputs.VERSION }}
-
-      - name: Verify docvet --version
-        run: docvet --version
-
-      - name: Verify docvet check --help
-        run: docvet check --help
-
+  # ---------------------------------------------------------------------------
+  # Update floating v1 tag for GitHub Action consumers.
+  # ---------------------------------------------------------------------------
   update-tags:
+    needs: [publish-pypi]
     runs-on: ubuntu-latest
-    needs: build-and-publish
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
The smoke test installed from production PyPI with only a 60-second sleep for propagation, causing race condition failures when the index hadn't updated yet (v1.6.3 publish failed). Restructure to match the proven adk-secure-sessions publish pattern: publish to TestPyPI first, smoke test from there, then publish to production.

- Split monolithic build-and-publish into build → publish-testpypi → smoke-test → publish-pypi
- Change trigger from `release: [published]` to `push: tags: ["v*"]` for reliability
- Add `--refresh` and `--index-strategy unsafe-best-match` to smoke test install
- Apply least-privilege permissions per-job instead of one combined job
- Add concurrency guard to prevent overlapping publishes

Test: CI only — publish pipeline validates on next release tag

**Action required:** Add TestPyPI trusted publisher (owner: `Alberto-Codes`, repo: `docvet`, workflow: `publish.yml`, environment: `testpypi`)

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Pipeline ordering: build → testpypi → smoke-test → pypi → update-tags
- TestPyPI trusted publisher must be configured before next release

### Related
- Failed run: Publish to PyPI #22559619892
- Pattern source: adk-secure-sessions publish.yml