### PR TITLE
chore(ci): suppress publish workflow warnings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,9 @@ jobs:
       contents: read
     steps:
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+          ignore-empty-workdir: true
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -109,6 +112,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+          ignore-empty-workdir: true
       - run: uv python install 3.12
 
       - name: Extract version from tag
@@ -151,6 +157,9 @@ jobs:
       attestations: write
     steps:
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+          ignore-empty-workdir: true
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -163,7 +172,7 @@ jobs:
       - name: Attest build provenance
         uses: astral-sh/attest-action@v0.0.5
         with:
-          files: dist/*
+          paths: dist/*
 
   # ---------------------------------------------------------------------------
   # Update floating v1 tag for GitHub Action consumers.


### PR DESCRIPTION
Suppress three categories of warnings in the publish workflow that fire on every release.

- Add `enable-cache: false` and `ignore-empty-workdir: true` to `setup-uv` steps in jobs that don't check out the repo (publish-testpypi, smoke-test, publish-pypi)
- Fix `attest-action` input: `files` → `paths` (renamed upstream)

Test: CI only — warnings only appear during publish runs

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- YAML-only change, no code impact

### Related
- Publish run with warnings: https://github.com/Alberto-Codes/docvet/actions/runs/22559908816