### PR TITLE
fix(ci): remove unsafe-best-match index strategy from smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,9 +130,8 @@ jobs:
       - name: Install from TestPyPI
         run: |
           uv pip install \
-            --index-url https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple/ \
-            --index-strategy unsafe-best-match \
+            --index-url https://pypi.org/simple/ \
+            --extra-index-url https://test.pypi.org/simple/ \
             --refresh \
             "docvet==${{ steps.version.outputs.version }}"
 


### PR DESCRIPTION
The publish pipeline smoke-test job used `--index-strategy unsafe-best-match` to resolve dependencies across TestPyPI and PyPI. This strategy merges version candidates from all configured indexes and selects the highest version — the same behavior that enabled the torchtriton supply chain attack against PyTorch in December 2022. While the blast radius here is contained (ephemeral CI, pinned version), the strategy is unnecessary and exposes transitive dependencies to dependency confusion.

- Swap index priority so PyPI is `--index-url` (primary) and TestPyPI is `--extra-index-url` (secondary)
- Drop `--index-strategy unsafe-best-match` — uv's default `first-index` strategy resolves deps from PyPI first, falling through to TestPyPI only for `docvet` (which doesn't exist on PyPI yet at smoke-test time)

Test: CI only — next tag-triggered publish run will validate

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [ ] Tests pass (`uv run pytest`)
- [ ] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Verify the index-swap logic: under uv's `first-index` default, the pinned `docvet==X.Y.Z` won't be found on PyPI (not yet published) so uv falls through to TestPyPI. All transitive deps resolve safely from PyPI.

### Related
- Same fix applied to Alberto-Codes/gepa-adk and Alberto-Codes/adk-secure-sessions