### PR TITLE
test(exports): add docvet.lsp to module coverage in test_exports.py

### DIFF
--- a/tests/unit/test_exports.py
+++ b/tests/unit/test_exports.py
@@ -82,6 +82,14 @@ class TestConfigExports:
         assert len(mod.__all__) == 4
 
 
+class TestLspExports:
+    def test_lsp_all_contains_start_server(self):
+        mod = importlib.import_module("docvet.lsp")
+        assert hasattr(mod, "__all__")
+        assert mod.__all__ == ["start_server"]
+        assert len(mod.__all__) == 1
+
+
 class TestInternalModulesExportNothing:
     @pytest.mark.parametrize(
         "module_path",
@@ -111,6 +119,7 @@ _ALL_DOCVET_MODULES = [
     "docvet.cli",
     "docvet.config",
     "docvet.discovery",
+    "docvet.lsp",
     "docvet.reporting",
 ]
 


### PR DESCRIPTION
The LSP module was missing from the `_ALL_DOCVET_MODULES` list in `test_exports.py`, so it was not covered by the module-level export validation tests (`TestAllModulesHaveAll`, `TestAllEntriesAreResolvable`, `TestNoPrivateNamesExported`).

- Add `docvet.lsp` to `_ALL_DOCVET_MODULES` list
- Add `TestLspExports` class verifying `__all__ == ["start_server"]`

Test: `uv run pytest tests/unit/test_exports.py -v`

Closes #208

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Straightforward addition — verify `docvet.lsp.__all__` matches the assertion.

### Related
Retro action from Epic 24 (LSP server implementation).