### PR TITLE
chore(presence): add Epic 28 retrospective and update sprint status

### DIFF
--- a/_bmad-output/implementation-artifacts/epic-28-retro-2026-03-02.md
+++ b/_bmad-output/implementation-artifacts/epic-28-retro-2026-03-02.md
@@ -1,0 +1,122 @@
+# Epic 28 Retrospective — Docstring Presence Check
+
+**Date:** 2026-03-02
+**Facilitator:** Bob (Scrum Master)
+**Participants:** Alberto-Codes (Project Lead), Alice (Product Owner), Charlie (Senior Dev), Dana (QA Engineer), Elena (Junior Dev)
+
+---
+
+## Epic Summary
+
+| Metric | Value |
+|--------|-------|
+| Stories | 3/3 completed (100%) |
+| Story types | Core function + CLI wiring + Documentation |
+| Debug sessions | 0 (zero-debug streak: 20+ stories since Epic 22) |
+| Test suite | 1106 (up from 988, +118 net new tests) |
+| Code review findings | 28.1: 5 (2M, 1M→L, 2L), 28.2: CC refactoring (CC=20, CC=17 → under threshold), 28.3: 4 (1H, 2M, 1L skipped) — all resolved |
+| Tech debt items | 0 new (SonarQube CC addressed proactively in 28.2) |
+| Production incidents | 0 |
+| New modules | `checks/presence.py`, `test_presence.py`, `test_docs_infrastructure.py` |
+
+### Stories
+
+| Story | Title | Type | Debug Sessions | Review Findings |
+|-------|-------|------|---------------|-----------------|
+| 28.1 | Core presence detection and configuration | Feature | 0 | 5 (adversarial + party mode) — all fixed |
+| 28.2 | CLI wiring and pipeline integration | Feature | 0 | CC refactoring (SonarQube-during-dev caught CC=20, CC=17) |
+| 28.3 | Documentation and migration guide | Docs | 0 | 4 (adversarial + party mode) — 3 fixed, 1 skipped by consensus |
+
+---
+
+## Successes
+
+- **Zero-debug streak continues (20+ stories)** — Progressive build pattern (core → CLI → docs) produced zero-debug implementations across all 3 stories. Story spec quality remains the #1 velocity multiplier.
+- **Post-roadmap planning worked** — Epic 27 retro said "No Epic 28 defined — full product roadmap complete." The team triaged GitHub issues, ran party mode on architecture, and produced a well-structured 3-story epic with clean FR/NFR coverage. Post-roadmap epics can match planned-epic quality.
+- **Epic 27 retro action item paid off concretely** — Running `analyze_code_snippet` during dev (not just review) caught CC=20 and CC=17 in 28.2. Three helpers extracted (`_write_timing`, `_format_coverage_line`, `_resolve_format`), both functions brought under threshold. This prevented a review round-trip.
+- **Security improvement** — Replaced interrogate's vulnerable supply chain (CVE in transitive dep) with a zero-dependency, pure-stdlib presence check. Users now get Layer 1 coverage from docvet itself.
+- **Cross-cutting quality from docs story** — 28.3 (docs-only) produced `test_docs_infrastructure.py` with 13 tests validating rules.yml schema, bidirectional rule-page consistency, and mkdocs.yml nav file existence. TEA-identified risk gap covered proactively.
+- **+118 net new tests** — 30 (28.1) + 48 (28.2) + 13 docs infra + 27 other = 118 net new across the epic.
+
+---
+
+## Challenges
+
+- **28.2 story file review section incomplete** — Story status says "review" in file header but "done" in sprint-status. Code Review section (Reviewer, Outcome, Findings) is blank. Work was done and SonarQube analysis verified, but paperwork gap in the story file.
+- **Epic spec had wrong category value** — Epic AC said `category="presence"` but `Finding.__post_init__` validates against `Literal["required", "recommended"]`. Caught during story creation (not during implementation), so impact was zero. But the epic spec had a gap that could have caused confusion.
+- **Brief enforcement gap** — PR #235 dropped interrogate from CI before the presence check was ready. Worked out because the epic shipped quickly, but there was a window where Layer 1 had no enforcement.
+
+---
+
+## Key Insights
+
+1. **Own your quality layer** — Replacing a third-party tool with your own gives security, control, and the ability to offer it to the community. interrogate's removal became a feature story, not a loss.
+2. **Retro action items compound** — SonarQube-during-dev went from "nice idea" (Epic 27) to "caught real CC violations" (Epic 28). Follow-through on retro commitments has measurable ROI.
+3. **Post-roadmap epics can be well-structured** — Issue triage + party mode consensus produces spec quality on par with planned epics. The "roadmap is done" moment is an inflection point, not an ending.
+4. **Docs stories can produce test infrastructure** — The TEA-identified gap in docs infrastructure testing was filled during a docs-only story. Cross-cutting improvements belong wherever they're discovered.
+
+---
+
+## Previous Retro Follow-Through (Epic 27)
+
+| # | Action Item | Status |
+|---|-------------|--------|
+| 1 | Run `analyze_code_snippet` during dev-story, not just code review | ✅ Completed — 28.1 Task 6.6, 28.2 Task 11.6 (caught CC=20, CC=17). Prevented review round-trip. |
+| 2 | Continue multi-layer review on all non-trivial stories | ✅ Completed — 28.1: adversarial + party mode. 28.3: adversarial + party mode. 28.2: SonarQube analysis (review section incomplete in story file). |
+
+**Carried Forward from Epic 27:**
+
+| Item | Status |
+|------|--------|
+| CLAUDE.md stale test structure section | Still backlog |
+| `test_exports.py` missing `docvet.lsp` module | ✅ Resolved (PR #237 merged) |
+| `cli.py:338` nested ternary S3358 (#204) | Still backlog |
+
+**Follow-through trend:** 4/4 → 2/4 → 1/4 → 3/3 → 3/3 → 3/3 → 3/3 → 4/6 → 7/8 → 2/2 → 1/1 → **2/2**
+
+---
+
+## Action Items
+
+### Process Improvements
+
+1. **Continue running `analyze_code_snippet` during dev-story** (carried forward — now proven)
+   - Owner: All (dev agent standard practice)
+   - Success criteria: CC verified before marking story done on code-changing stories
+
+2. **Add docs infrastructure tests when touching docs**
+   - Owner: SM (story creation template reminder)
+   - Success criteria: Stories modifying `rules.yml`, `mkdocs.yml`, or docs pages include infrastructure test verification
+
+### Technical Debt
+
+None new from Epic 28.
+
+**Still carried forward:**
+- CLAUDE.md stale test structure section (from Epic 25 review)
+- `cli.py:338` nested ternary S3358 (GitHub issue #204)
+
+### Team Agreements
+
+- Progressive build pattern (core → CLI → docs) is the standard for new check epics
+- Post-roadmap epics use issue triage + party mode consensus for planning
+- Retro action items are load-bearing — follow-through trend must stay above 80%
+
+---
+
+## Readiness Assessment
+
+- **Testing & Quality:** 1106 tests passing, 100% docvet coverage, zero findings
+- **Deployment:** All 3 PRs merged to main, ready for release
+- **Technical Health:** Stable, CC refactored proactively, zero new debt
+- **Unresolved Blockers:** None
+- **Epic 29 Readiness:** Dependencies met, LSP pattern established as precedent
+
+---
+
+## Next Steps
+
+1. Trigger release-please for v1.7.0 (presence check feature release)
+2. Begin Epic 29 (MCP Server) — create story 29.1 when ready
+3. Address carried-forward tech debt as maintenance work
+4. Review action items in next standup

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -232,11 +232,11 @@ development_status:
   epic-27-retrospective: done  # 2026-02-28
 
   # Epic 28: Docstring Presence Check
-  epic-28: in-progress
+  epic-28: done
   28-1-core-presence-detection-and-configuration: done
   28-2-cli-wiring-and-pipeline-integration: done
   28-3-documentation-and-migration-guide: done
-  epic-28-retrospective: optional
+  epic-28-retrospective: done  # 2026-03-02
 
   # Epic 29: MCP Server & Agentic Integration
   epic-29: backlog


### PR DESCRIPTION
Epic 28 (Docstring Presence Check) is complete — all 3 stories shipped, 118 net new tests, zero-debug streak continues. This PR adds the retrospective document and updates sprint-status.yaml.

- Add Epic 28 retrospective with successes, challenges, insights, and action items
- Update sprint-status.yaml: epic-28 → done, epic-28-retrospective → done

Test: CI only (no code changes)

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
BMAD artifacts only — no source code changes.

### Related
Closes out Epic 28 (Stories 28.1–28.3: #240, #244, #249)