### PR TITLE
fix(ci): decouple TestPyPI from production publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,9 +144,11 @@ jobs:
   # ---------------------------------------------------------------------------
   # Publish to PyPI — production release.
   # Uses OIDC trusted publishing (no stored tokens).
+  # TestPyPI is informational only — a TestPyPI outage must never block a
+  # production release (see issue #252).
   # ---------------------------------------------------------------------------
   publish-pypi:
-    needs: [smoke-test]
+    needs: [build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi


### PR DESCRIPTION
TestPyPI 503 outage blocked the v1.7.0 production release. The sequential chain (build → publish-testpypi → smoke-test → publish-pypi) means any TestPyPI failure hard-blocks PyPI publishing.

- Change `publish-pypi` to `needs: [build]` instead of `needs: [smoke-test]`
- TestPyPI + smoke-test still run in parallel as an informational path
- A TestPyPI outage no longer blocks production releases

This follows the PyPA recommended pattern where TestPyPI is a health indicator, not a gate.

Test: CI only — workflow structural change

Closes #252

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Single `needs:` line change in publish.yml. Pipeline topology changes from sequential to parallel for TestPyPI path.

### Related
- Unblocks v1.7.0 release (TestPyPI has been 503 for the past hour)
- Issue #252