### PR TITLE
chore(docs): add Ruff badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/docvet)](https://pypi.org/project/docvet/)
 [![Python](https://img.shields.io/pypi/pyversions/docvet)](https://pypi.org/project/docvet/)
 [![License](https://img.shields.io/pypi/l/docvet)](https://github.com/Alberto-Codes/docvet/blob/main/LICENSE)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![docs vetted](https://img.shields.io/badge/docs%20vetted-docvet-purple)](https://github.com/Alberto-Codes/docvet)
 
 # docvet


### PR DESCRIPTION
Add official Ruff badge between License and docvet badges, signaling modern Python tooling.

- Add Ruff badge using official astral-sh endpoint URL
- Badge order: CI → Coverage → PyPI → Python → License → Ruff → docvet

Test: CI only — README-only change

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass
- [x] Lint passes
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- `README.md`: badge addition only, no content changes

### Related
- Mirror change in Alberto-Codes/adk-secure-sessions