### PR TITLE
chore(docvet): enforce presence check with 100% threshold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,10 @@ docstring-code-line-length = "dynamic"
 # Docvet
 # --------------------------------------------------------------------------- #
 [tool.docvet]
-fail-on = ["enrichment", "freshness", "coverage", "griffe"]
+fail-on = ["enrichment", "freshness", "coverage", "griffe", "presence"]
+
+[tool.docvet.presence]
+min-coverage = 100.0
 
 # --------------------------------------------------------------------------- #
 # Ty (type checker)


### PR DESCRIPTION
Docvet v1.7.0 added a zero-dependency presence check that detects missing docstrings. This project already has 100% docstring coverage (57/57 symbols) but wasn't enforcing it. Adding presence to the fail-on list prevents regressions.

- Add `"presence"` to `fail-on` list in `[tool.docvet]`
- Add `[tool.docvet.presence]` section with `min-coverage = 100.0`

Test: `uv run docvet check --all --verbose` — 100% coverage, exit 0

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Config-only change — no code changes.

### Related
Part of presence enforcement rollout across docvet, adk-secure-sessions, and gepa-adk.