### PR TITLE
fix(mcp): correct server.json for MCP Registry compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,4 +192,4 @@ Are you using docvet? Open a pull request to add your project here.
 
 MIT -- see [LICENSE](https://github.com/Alberto-Codes/docvet/blob/main/LICENSE) for details.
 
-mcp-name: io.github.alberto-codes/docvet
+mcp-name: io.github.Alberto-Codes/docvet

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
-  "name": "io.github.alberto-codes/docvet",
-  "description": "Docstring quality vetting -- enrichment, freshness, coverage, presence, and griffe checks for Python projects",
+  "name": "io.github.Alberto-Codes/docvet",
+  "description": "Docstring quality vetting for Python -- enrichment, freshness, coverage, and presence checks",
   "version": "1.8.0",
   "status": "active",
   "repository": {
@@ -11,7 +11,7 @@
   "website_url": "https://alberto-codes.github.io/docvet/",
   "packages": [
     {
-      "registry_type": "pypi",
+      "registryType": "pypi",
       "identifier": "docvet",
       "version": "1.8.0",
       "transport": {


### PR DESCRIPTION
MCP Registry publication failed with three validation errors: name casing must match GitHub username exactly, description exceeded 100-char limit, and `registry_type` must be camelCase `registryType` per the registry API.

- Fix `name` and `mcp-name` casing to `io.github.Alberto-Codes/docvet` (matches GitHub username)
- Shorten description to ≤100 characters
- Change `registry_type` to `registryType` (camelCase per registry API)

Test: `mcp-publisher publish` (after release to PyPI)

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Metadata-only changes to `server.json` and `README.md`. No code changes.

### Related
Blocking MCP Registry publication.