### PR TITLE
docs: add privacy policy page

### DIFF
--- a/docs/site/privacy.md
+++ b/docs/site/privacy.md
@@ -1,0 +1,42 @@
+---
+title: Privacy Policy
+---
+
+# Privacy Policy
+
+**Effective date:** March 4, 2026
+
+## Overview
+
+docvet is an open-source Python CLI tool for docstring quality analysis. It runs entirely on your local machine and does not collect, transmit, or store any user data.
+
+## Data Collection
+
+docvet collects **no data**. Specifically:
+
+- No telemetry or usage analytics
+- No crash reports or error tracking
+- No personal information
+- No source code leaves your machine
+
+All analysis (AST parsing, git operations, griffe checks) is performed locally using your filesystem and local git repository.
+
+## Network Access
+
+docvet makes **no network requests**. It has no internet-facing dependencies at runtime. The only network activity occurs during installation (`pip install docvet`), which is handled by pip/uv and the PyPI registry.
+
+## Third-Party Services
+
+docvet does not integrate with any third-party analytics, advertising, or tracking services.
+
+## Editor and Agent Integrations
+
+The LSP server (`docvet lsp`) and MCP server (`docvet mcp`) communicate exclusively over stdio with the local editor or agent process. No data is sent to external servers.
+
+## Changes
+
+If this policy changes, updates will be posted to this page with a revised effective date.
+
+## Contact
+
+For questions about this policy, open an issue on [GitHub](https://github.com/Alberto-Codes/docvet/issues).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
   - Architecture: architecture.md
   - CLI Reference: cli-reference.md
   - Glossary: glossary.md
+  - Privacy Policy: privacy.md
   - Reference: reference/
 
 markdown_extensions:


### PR DESCRIPTION
Anthropic Plugin Directory requires a privacy policy URL for Verified status. docvet collects no data, so this is a simple no-collection policy page.

- Add privacy policy page to docs site
- Add nav entry in mkdocs.yml

Test: CI only

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Docs-only change. No code.

### Related
Blocking Anthropic Plugin Directory submission.