### PR TITLE
docs(mcp): add per-client MCP config snippets

### DIFF
--- a/docs/site/ai-integration.md
+++ b/docs/site/ai-integration.md
@@ -13,35 +13,7 @@ Add docvet to your AI coding workflow. Drop a snippet into your agent's instruct
 
 For the richest AI agent integration, use docvet's [MCP server](editor-integration.md#mcp-server). Instead of parsing CLI text output, agents receive structured JSON results with findings, summaries, and coverage data.
 
-### Claude Code Configuration
-
-Add to your `~/.claude.json`:
-
-```json
-{
-  "mcpServers": {
-    "docvet": {
-      "command": "docvet",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-Or use `uvx` to run without pre-installing:
-
-```json
-{
-  "mcpServers": {
-    "docvet": {
-      "command": "uvx",
-      "args": ["docvet[mcp]", "mcp"]
-    }
-  }
-}
-```
-
-Once configured, the agent can call `docvet_check` and `docvet_rules` tools directly. See the [MCP Server tool reference](editor-integration.md#mcp-server) for parameters and response schemas.
+See [Editor Integration > MCP Server](editor-integration.md#mcp-server) for client configuration (Claude Code, VS Code, Cursor, Windsurf, Claude Desktop), available tools, and response schemas.
 
 ## Which File Should I Use?
 

--- a/docs/site/editor-integration.md
+++ b/docs/site/editor-integration.md
@@ -64,13 +64,102 @@ pip install docvet[mcp]
 
 This installs `docvet` and the [`mcp`](https://pypi.org/project/mcp/) protocol library.
 
-### Start the Server
+### Client Configuration
 
-```bash
-docvet mcp
-```
+Your MCP client starts the server automatically. Configure it for your tool:
 
-The server runs on stdio. You do not run this manually — your MCP client (Claude Code, Cursor, etc.) starts it automatically using its configuration.
+=== "Claude Code (CLI)"
+
+    The fastest way — no JSON editing needed:
+
+    ```bash
+    claude mcp add --transport stdio --scope project docvet -- uvx "docvet[mcp]" mcp
+    ```
+
+    Use `--scope user` instead to make it available across all projects.
+
+=== "Claude Code (JSON)"
+
+    Add to `.mcp.json` in your project root:
+
+    ```json
+    {
+      "mcpServers": {
+        "docvet": {
+          "command": "uvx",
+          "args": ["docvet[mcp]", "mcp"]
+        }
+      }
+    }
+    ```
+
+=== "VS Code"
+
+    Add to `.vscode/mcp.json`:
+
+    ```json
+    {
+      "servers": {
+        "docvet": {
+          "type": "stdio",
+          "command": "uvx",
+          "args": ["docvet[mcp]", "mcp"]
+        }
+      }
+    }
+    ```
+
+    !!! warning
+        VS Code uses `"servers"` as the top-level key, not `"mcpServers"`.
+
+=== "Cursor"
+
+    Add to `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
+
+    ```json
+    {
+      "mcpServers": {
+        "docvet": {
+          "command": "uvx",
+          "args": ["docvet[mcp]", "mcp"]
+        }
+      }
+    }
+    ```
+
+=== "Windsurf"
+
+    Add to `~/.codeium/windsurf/mcp_config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "docvet": {
+          "command": "uvx",
+          "args": ["docvet[mcp]", "mcp"]
+        }
+      }
+    }
+    ```
+
+=== "Claude Desktop"
+
+    Add to `claude_desktop_config.json` (macOS: `~/Library/Application Support/Claude/`, Windows: `%APPDATA%\Claude\`):
+
+    ```json
+    {
+      "mcpServers": {
+        "docvet": {
+          "command": "uvx",
+          "args": ["docvet[mcp]", "mcp"]
+        }
+      }
+    }
+    ```
+
+    Restart Claude Desktop after editing.
+
+docvet is also listed on the [MCP Registry](https://registry.modelcontextprotocol.io) — search for `docvet` to find it.
 
 ### Available Tools
 


### PR DESCRIPTION
The MCP Server section in editor-integration.md only showed Claude Code JSON config. Now that docvet is listed on the MCP Registry, users discovering it may use any MCP-capable client.

- Add tabbed config snippets for Claude Code (CLI + JSON), VS Code, Cursor, Windsurf, and Claude Desktop
- Add MCP Registry callout linking to the registry listing
- Replace duplicate Claude Code JSON config in ai-integration.md with a cross-reference to editor-integration.md

Test: `uv run mkdocs build` (no errors)

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Verify tabbed content renders correctly in mkdocs-material. VS Code uses `"servers"` not `"mcpServers"` — the warning admonition calls this out.

### Related
MCP Registry listing: https://registry.modelcontextprotocol.io