### PR TITLE
fix(plugin): add marketplace.json and update install instructions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "docvet",
+  "owner": {
+    "name": "Alberto-Codes"
+  },
+  "metadata": {
+    "description": "Docvet Python docstring quality tools for Claude Code"
+  },
+  "plugins": [
+    {
+      "name": "docvet-lsp",
+      "source": {
+        "source": "github",
+        "repo": "Alberto-Codes/docvet"
+      },
+      "description": "Real-time docstring quality diagnostics for Python files",
+      "homepage": "https://alberto-codes.github.io/docvet/",
+      "repository": "https://github.com/Alberto-Codes/docvet",
+      "license": "MIT",
+      "keywords": ["python", "docstrings", "linting", "code-quality", "lsp"],
+      "category": "code-intelligence"
+    }
+  ]
+}

--- a/docs/site/editor-integration.md
+++ b/docs/site/editor-integration.md
@@ -249,7 +249,8 @@ docvet ships as a [Claude Code plugin](https://docs.anthropic.com/en/docs/claude
 ### Install
 
 ```bash
-claude plugin install github:Alberto-Codes/docvet
+claude plugin marketplace add Alberto-Codes/docvet
+claude plugin install docvet-lsp@docvet
 ```
 
 **Prerequisites:** `pip install docvet[lsp]` (the plugin calls `docvet lsp` under the hood).


### PR DESCRIPTION
Claude Code v2.1.x changed the plugin install model — `claude plugin install github:owner/repo` now looks for the plugin in configured marketplaces rather than installing directly. Without a `marketplace.json`, users get "not found in any configured marketplace."

- Add `.claude-plugin/marketplace.json` so the repo serves as its own marketplace
- Update install instructions in editor-integration.md to the two-step flow: `claude plugin marketplace add` then `claude plugin install`

Test: `claude plugin validate .claude-plugin` (user tested — old install command confirmed broken)

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Verify marketplace.json format matches the Claude Code plugin marketplace spec. Test the two-step install flow after merging.

### Related
- Claude Code plugin marketplace docs: https://code.claude.com/docs/en/plugin-marketplaces