### PR TITLE
test(lsp,cli): strengthen 5 weak assertions to verify arguments

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1769,8 +1769,7 @@ class TestOutputAndExit:
         self._call(
             ctx, {"enrichment": [make_finding()]}, DocvetConfig(), 1, ["enrichment"]
         )
-        self.mock_format_terminal.assert_called_once()
-        assert self.mock_format_terminal.call_args[1]["no_color"] is True
+        self.mock_format_terminal.assert_called_once_with(ANY, no_color=True)
 
     def test_non_tty_stdout_suppresses_ansi(self, monkeypatch, make_finding):
         monkeypatch.delenv("NO_COLOR", raising=False)
@@ -1779,8 +1778,7 @@ class TestOutputAndExit:
         self._call(
             ctx, {"enrichment": [make_finding()]}, DocvetConfig(), 1, ["enrichment"]
         )
-        self.mock_format_terminal.assert_called_once()
-        assert self.mock_format_terminal.call_args[1]["no_color"] is True
+        self.mock_format_terminal.assert_called_once_with(ANY, no_color=True)
 
     def test_output_flag_forces_no_color_true(self, make_finding):
         finding = make_finding()

--- a/tests/unit/test_lsp.py
+++ b/tests/unit/test_lsp.py
@@ -292,7 +292,12 @@ class TestDidOpen:
             "x = 1\n",
             mock_server.docvet_config,
         )
-        mock_server.text_document_publish_diagnostics.assert_called_once()
+        mock_server.text_document_publish_diagnostics.assert_called_once_with(
+            types.PublishDiagnosticsParams(
+                uri="file:///fake/project/src/app.py",
+                diagnostics=[],
+            )
+        )
 
 
 class TestDidSave:
@@ -312,7 +317,12 @@ class TestDidSave:
                 params.text_document.uri,
                 params.text,
             )
-        mock_server.text_document_publish_diagnostics.assert_called_once()
+        mock_server.text_document_publish_diagnostics.assert_called_once_with(
+            types.PublishDiagnosticsParams(
+                uri="file:///fake/project/src/app.py",
+                diagnostics=[],
+            )
+        )
 
     def test_falls_back_to_workspace_doc_when_text_none(
         self, mock_server: MagicMock
@@ -345,10 +355,15 @@ class TestDidSave:
         uri = "file:///fake/project/README.md"
         with patch("docvet.lsp._check_file", return_value=[]) as mock_check:
             _publish_diagnostics(mock_server, uri, "# Title")
-        mock_check.assert_called_once()
-        call_args = mock_server.text_document_publish_diagnostics.call_args
-        params = call_args[0][0]
-        assert params.diagnostics == []
+        mock_check.assert_called_once_with(
+            mock_server, uri, "# Title", mock_server.docvet_config
+        )
+        mock_server.text_document_publish_diagnostics.assert_called_once_with(
+            types.PublishDiagnosticsParams(
+                uri=uri,
+                diagnostics=[],
+            )
+        )
 
 
 class TestCliLspCommand:


### PR DESCRIPTION
Weak `assert_called_once()` calls only verify call count, not arguments.
Per Dev Quality Checklist (Epic 5+): "verify arguments, not just call
count." Identified in TEA test-review session (2026-03-05, score 91/100).

- Replace 2 `assert_called_once()` + manual `call_args` checks with `assert_called_once_with(ANY, no_color=True)` in `test_cli.py`
- Replace 3 `assert_called_once()` calls with `assert_called_once_with(PublishDiagnosticsParams(...))` in `test_lsp.py`
- Strengthen 1 additional `mock_check.assert_called_once()` to verify all 4 `_check_file` arguments

Test: `uv run pytest tests/unit/test_cli.py tests/unit/test_lsp.py -v`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Pure test assertion quality improvement — no production code changes. Each replacement is strictly stronger (verifies arguments instead of just call count).

### Related
- Dev Quality Checklist: `.claude/rules/dev-quality-checklist.md` (Epic 5+ assertion strength)