### PR TITLE
docs(bmad): add Growth phase PRD, architecture, and epics for Epics 31-33

### DIFF
--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -36,9 +36,18 @@ stepsCompleted:
   - 'v1-publish-6'
   - 'v1-publish-7'
   - 'v1-publish-8'
-lastStep: 'v1-publish-8'
+  - 'growth-2'
+  - 'growth-3-skip'
+  - 'growth-4'
+  - 'growth-5'
+  - 'growth-6'
+  - 'growth-7'
+  - 'growth-8'
+lastStep: 'growth-8'
 status: 'complete'
 completedAt: '2026-02-11'
+growthCompletedAt: '2026-03-07'
+growthStartedAt: '2026-03-06'
 reportingStartedAt: '2026-02-11'
 freshnessStartedAt: '2026-02-09'
 griffeStartedAt: '2026-02-11'
@@ -53,6 +62,7 @@ inputDocuments:
   - 'docs/project-overview.md'
   - 'docs/development-guide.md'
   - 'docs/source-tree-analysis.md'
+  - '_bmad-output/planning-artifacts/epics-quick-wins-lifecycle-visibility.md'
   - 'src/docvet/ast_utils.py'
   - 'src/docvet/config.py'
   - 'src/docvet/checks/__init__.py'
@@ -3960,3 +3970,788 @@ The `src/docvet/` tree gets only `__all__` declarations and a `Finding` re-expor
 1. Decision 1 (Build System) → Decision 6 (API Surface) — foundation layer
 2. Decision 2 (Docs Architecture) → Decision 3 (Rule Pages) — docs layer
 3. Decision 4 (Pre-commit) + Decision 5 (GitHub Action) — integration layer
+
+---
+
+## Growth Phase (Epics 31-33) — Project Context Analysis
+
+### Requirements Overview
+
+The Growth phase adds 30 functional requirements (FR128-FR157) across 7 categories and 10 non-functional requirements (NFR67-NFR76) across 6 categories. The three epics target distinct capability tiers:
+
+| Epic | Theme | FRs | Key Capabilities |
+|------|-------|-----|-----------------|
+| 31 — Quick Wins | Immediate developer value | FR128-FR141 | `docvet fix` (AST scaffolding), inline suppression (`# docvet: ignore[rule-id]`), `--summary` flag, `docvet config show` |
+| 32 — Lifecycle | CI/CD pipeline integration | FR142-FR149 | Dynamic badge (shields.io JSON via GitHub Gist), VS Code extension (thin LSP wrapper), SARIF v2.1.0 output |
+| 33 — Visibility | Ecosystem presence | FR150-FR157 | Flagship OSS runs (FastAPI, Pydantic, typer, httpx), curated results in docs site |
+
+### Technical Constraints & Dependencies
+
+**Existing infrastructure leveraged:**
+
+- **`_output_and_exit`** (cli.py) — 8-step unified output pipeline. All new output formats (SARIF, summary, badge JSON) and filtering (suppression) integrate here.
+- **`Finding` frozen dataclass** — 6-field immutable type (`file`, `line`, `symbol`, `rule`, `message`, `category`). Stable for v1; suppression and fix both consume this type without modification.
+- **`_RULE_DISPATCH`** (enrichment.py) — table-driven dispatch. Fix command needs the same detection logic but with different output (scaffold text vs. Finding).
+- **`format_json`** (reporting.py) — SARIF formatter can reuse ~60% of JSON serialization logic.
+- **`get_documented_symbols()`** — already returns symbol counts per check; `--summary` percentages derive from these without changing check runner return types.
+- **LSP server** (lsp.py) — VS Code extension wraps `docvet lsp --stdio`; no LSP changes needed for the extension itself.
+
+**Hard constraints:**
+
+- No runtime dependencies added (fix uses stdlib `ast` + string ops, no libcst, no LLM)
+- No `Finding` dataclass changes (suppression is a post-filter, fix consumes findings as-is)
+- No check runner return type changes (summary uses parallel `symbols_by_check` dict)
+- SARIF must validate against v2.1.0 JSON schema
+- Badge JSON must conform to shields.io endpoint schema
+- VS Code extension lives in separate `docvet-vscode` repo
+
+### Cross-Cutting Concerns
+
+Five architectural concerns surfaced during party-mode review. These require explicit decisions in subsequent steps:
+
+**1. Fix-Enrichment Coupling — Shared Detection Layer**
+
+The fix command and enrichment check both need to detect missing docstring sections. Currently, `_check_*` functions in enrichment.py produce `Finding` objects. Fix needs the same detection but outputs scaffold text (e.g., `Raises:\n    ValueError: ...\n`).
+
+*Concern:* Duplicating detection logic creates drift risk. The architecture must define a shared `_detect_*` layer consumed by both `_check_*` (returns Finding) and `_scaffold_*` (returns section text).
+
+*Impact:* Enrichment module refactor — extract detection from formatting. This is the highest-risk decision in the Growth phase.
+
+**2. Suppression Pipeline Position — Step 1.5 in `_output_and_exit`**
+
+Inline suppression (`# docvet: ignore[rule-id]`) must filter findings before any output formatting. The natural insertion point is inside `_output_and_exit` as step 1.5: after flatten (step 1), before verbose header (step 3).
+
+*Concern:* Suppression must read source files to find ignore comments, adding I/O to what was previously a pure output pipeline. The architecture must decide whether suppression lives inside `_output_and_exit` or as a pre-filter called before it.
+
+*Impact:* Pipeline architecture — purity vs. cohesion tradeoff.
+
+**3. Symbol Count for `--summary` — Parallel Collection**
+
+`--summary` needs total symbol counts per check to compute percentages (e.g., "enrichment: 42/50 symbols clean = 84%"). The `get_documented_symbols()` function already provides counts, but check runners don't currently return them.
+
+*Concern:* Changing check runner return types would break the existing API. Instead, a parallel `symbols_by_check` dict can be populated during discovery and passed alongside findings.
+
+*Impact:* Discovery module extension — minimal, additive change.
+
+**4. Fix + Suppression Interaction**
+
+When `docvet fix` scaffolds missing sections, it must respect existing suppression comments. If a symbol has `# docvet: ignore[missing-raises]`, the fix command should not scaffold a Raises section for it.
+
+*Concern:* Fix must run suppression filtering on detection results before scaffolding. This creates a dependency: fix → suppression → detection, requiring suppression to be available as a library function, not just a pipeline step.
+
+*Impact:* Suppression must be both a pipeline filter (for output) and a callable function (for fix). Design accordingly.
+
+**5. Badge Data Source — `--badge-json` Flag vs. Parsing**
+
+Dynamic badges need a JSON payload with label/message/color. Two approaches: (a) a dedicated `--badge-json` flag that emits shields.io-compatible JSON, or (b) a CI step that parses `--format json` output and constructs the badge payload.
+
+*Concern:* A dedicated flag is cleaner for CI but adds surface area. Parsing existing JSON output is fragile but requires zero new code.
+
+*Impact:* CLI surface area decision — likely favors dedicated flag for reliability.
+
+## Growth Phase — Core Architectural Decisions
+
+### Decision Priority Analysis
+
+**Critical Decisions (Block Implementation):**
+1. Fix-Enrichment shared detection layer
+2. Suppression architecture (post-filter + callable)
+3. Fix + Suppression interaction
+
+**Important Decisions (Shape Architecture):**
+4. Summary symbol counting
+5. SARIF formatter design
+6. Badge JSON output
+7. Config introspection
+
+**Deferred Decisions (Implementation-time):**
+- VS Code extension packaging (separate repo, thin LSP wrapper — no docvet core changes)
+- Flagship OSS run curation (docs-only, no core changes)
+
+### Decision 1: Fix-Enrichment Shared Detection Layer
+
+**Decision:** Extract `_detect_*` functions for complex rules only (4 of 10), returning rule-specific types. Simpler rules inline detection in the fix scaffolder.
+
+The fix command and enrichment check both detect missing docstring sections. Currently, `_check_*` functions interleave detection and Finding construction. For fix, the same detection must produce scaffold text instead of Findings.
+
+**Extraction scope — 4 complex rules only:**
+
+| Rule | `_detect_*` Return Type | Why Extract |
+|------|------------------------|-------------|
+| `missing-raises` | `list[str]` (exception names) | ~15 lines of exception walking + deduplication + re-raise filtering |
+| `missing-attributes` | `list[str]` (field names) | 5-branch dispatch (dataclass, NamedTuple, TypedDict, plain class, `__init__.py`) |
+| `missing-warns` | `list[str]` (warning category names) | `warnings.warn()` call walking + category extraction |
+| `missing-other-parameters` | `list[str]` (parameter names) | `**kwargs` detection + parameter diffing |
+
+**Not extracted — 3 simple rules (inline in scaffolder):**
+
+| Rule | Detection Complexity | Why Inline |
+|------|---------------------|------------|
+| `missing-yields` | `any(isinstance(n, ast.Yield) for n in ast.walk(body))` — one-liner | Extraction adds ceremony without value |
+| `missing-receives` | Same pattern with `ast.Yield` value check — one-liner | Same |
+| `missing-examples` | Symbol kind check against config list — one-liner | Same |
+
+**Not applicable — 3 docstring-only rules:**
+`missing-typed-attributes`, `missing-cross-references`, `prefer-fenced-code-blocks` — scaffolding is trivial or not applicable for fix.
+
+```python
+# Detection layer (shared) — returns rule-specific evidence
+def _detect_missing_raises(
+    symbol: Symbol,
+    node_index: dict[int, _NodeT],
+) -> list[str]:
+    """Return exception names raised but undocumented."""
+    ...
+
+# Enrichment consumer — wraps detection in a Finding
+def _check_missing_raises(
+    symbol: Symbol, sections: set[str], node_index: dict[int, _NodeT],
+    config: EnrichmentConfig, file_path: str,
+) -> Finding | None:
+    if "Raises" in sections:
+        return None
+    exceptions = _detect_missing_raises(symbol, node_index)
+    if not exceptions:
+        return None
+    return Finding(file_path, symbol.line, symbol.name, "missing-raises", ...)
+
+# Fix consumer — wraps detection in scaffold text
+def _scaffold_raises(
+    symbol: Symbol, node_index: dict[int, _NodeT],
+) -> str | None:
+    exceptions = _detect_missing_raises(symbol, node_index)
+    if not exceptions:
+        return None
+    return "Raises:\n" + "".join(f"    {e}: ...\n" for e in exceptions)
+```
+
+**Test preservation:** Existing enrichment tests (415) remain unchanged. `_check_*` functions are refactored to call `_detect_*` internally but their external behavior is identical — black-box preservation. New `_detect_*` unit tests are additive.
+
+**Where code lives:**
+- `_detect_*` functions stay in `enrichment.py` (private, no new module)
+- `_scaffold_*` functions live in new `checks/fix.py`
+- `_check_*` functions updated to call `_detect_*` internally
+
+**Anti-patterns:**
+- Duplicating detection logic in `fix.py` (drift risk)
+- Extracting one-liner detections into separate functions (unnecessary ceremony)
+- Having `_check_*` return both Finding and scaffold text (responsibility mixing)
+- Using `libcst` or any AST mutation library (violates zero-new-deps constraint)
+
+### Decision 2: Suppression Architecture
+
+**Decision:** Standalone `suppression.py` module with dual interface — batch filter for the pipeline, single-check function for fix. Suppression owns its own file I/O.
+
+Two suppression scopes:
+
+- **Line-level:** `# docvet: ignore[rule-id]` on the line of the symbol definition
+- **File-level:** `# docvet: ignore-file[rule-id]` anywhere in the file
+
+```python
+# New module: src/docvet/suppression.py
+
+def is_suppressed(symbol_line: int, rule_id: str, source: str) -> bool:
+    """Check if a single rule is suppressed for a symbol.
+
+    Used by fix to skip scaffolding for suppressed rules.
+    """
+    ...
+
+def filter_suppressed(findings: list[Finding]) -> list[Finding]:
+    """Remove findings suppressed by inline comments.
+
+    Reads source files using Finding.file paths. Each unique file
+    is read at most once (cached internally for the batch).
+    """
+    ...
+```
+
+**Pipeline position:** Called in `_output_and_exit` between step 2 (flatten) and step 3 (verbose header). Suppression reads files itself using `Finding.file` paths — no `file_sources` parameter threaded through the pipeline. This keeps `_output_and_exit`'s signature stable.
+
+**Edge case positions:**
+- **Unknown rule IDs:** Silently ignored (safe direction — `# docvet: ignore[typo-rule]` does nothing, no warning). This matches ruff/pylint behavior.
+- **Bare `ignore` without brackets:** Supported. `# docvet: ignore` (no brackets) suppresses all rules for that line. `# docvet: ignore-file` suppresses all rules for that file. This matches ruff's `# noqa` convention (no code = all rules). FR17's verbose reporting mitigates accidental blanket suppression.
+- **Multiple rules:** `# docvet: ignore[rule-a,rule-b]` supported via comma-separated list inside brackets.
+
+**Why a separate module:** Both `_output_and_exit` (pipeline) and `fix.py` (library) need suppression. A function in `cli.py` would force `fix.py` to import from the CLI module. A standalone `suppression.py` is importable from both.
+
+**Anti-patterns:**
+- Suppression inside individual `_check_*` functions (violates separation of concerns)
+- Threading `file_sources` through `_output_and_exit` (signature bloat, callers must change)
+- `.docvetignore` file-based suppression (out of scope, no FR for it)
+- Bare `# docvet: ignore` suppressing all rules (implicit > explicit)
+
+### Decision 3: Fix + Suppression Interaction
+
+**Decision:** Fix runs detection → suppression filter → scaffold on unsuppressed results.
+
+```python
+# In fix.py orchestrator
+for symbol in symbols:
+    sections = _parse_sections(symbol.docstring)
+    for rule_id, detect_fn in _FIX_DISPATCH:
+        if is_suppressed(symbol.line, rule_id, source):
+            continue
+        evidence = detect_fn(symbol, node_index)
+        if evidence:
+            scaffold = _scaffold(rule_id, evidence)
+            # ... insert scaffold into docstring
+```
+
+This means `suppression.py` exposes both `is_suppressed` (for fix, per-rule check) and `filter_suppressed` (for pipeline, batch filter).
+
+**Rationale:** A user who writes `# docvet: ignore[missing-raises]` expects fix to not scaffold a Raises section. Suppression intent must be respected by both output and fix paths.
+
+### Decision 4: Summary Symbol Counting
+
+**Decision:** Parallel `symbols_by_check` dict populated during check dispatch, no check runner return type changes.
+
+Each check runner already receives parsed files. The CLI dispatch functions (`_run_enrichment`, etc.) can count total symbols from `get_documented_symbols()` calls already happening. These counts are collected into a `dict[str, int]` and passed to a new `--summary` display.
+
+```python
+# In _run_enrichment (cli.py) — count is a byproduct of existing parsing
+symbols = get_documented_symbols(tree)
+symbol_counts["enrichment"] += len(symbols)
+# ... existing check_enrichment call unchanged
+```
+
+**Summary formula:** `clean_pct = ((total_symbols - finding_count) / total_symbols) * 100`
+
+**Output:** One line per check on stderr, after the existing summary line:
+
+```
+enrichment: 42/50 symbols clean (84.0%)
+freshness: 48/50 symbols clean (96.0%)
+```
+
+**Anti-patterns:**
+- Changing check runner return types to include counts (API break)
+- Re-parsing files just for counting (wasteful)
+- Computing percentages inside check runners (presentation concern)
+
+### Decision 5: SARIF Formatter
+
+**Decision:** New `format_sarif()` in `reporting.py`, reusing severity derivation from `format_json`.
+
+SARIF v2.1.0 is a well-defined JSON schema. The formatter maps Finding fields to SARIF locations and results:
+
+```python
+def format_sarif(
+    findings: list[Finding],
+    file_count: int,
+) -> str:
+    """Format findings as SARIF v2.1.0 JSON for GitHub Code Scanning."""
+    ...
+```
+
+**Finding → SARIF mapping:**
+
+| Finding field | SARIF field |
+|--------------|-------------|
+| `file` | `result.locations[0].physicalLocation.artifactLocation.uri` |
+| `line` | `result.locations[0].physicalLocation.region.startLine` |
+| `rule` | `result.ruleId` + `run.tool.driver.rules[].id` |
+| `message` | `result.message.text` |
+| `category` | `result.level` (`required` → `"warning"`, `recommended` → `"note"`) |
+| `symbol` | `result.locations[0].logicalLocations[0].name` |
+
+**Integration:** New `OutputFormat.SARIF = "sarif"` enum member. `_emit_findings` dispatches to `format_sarif` like other formats. Reuses severity derivation logic from `format_json` (extract to shared helper if needed).
+
+### Decision 6: Badge JSON Output
+
+**Decision:** Dedicated `--badge-json PATH` flag on `docvet check` that writes shields.io endpoint-compatible JSON to a file.
+
+```python
+# Output format:
+{
+  "schemaVersion": 1,
+  "label": "docvet",
+  "message": "84% clean",
+  "color": "green"
+}
+```
+
+**Color thresholds (hardcoded):** green >= 90%, yellow >= 70%, orange >= 50%, red < 50%. These are conventions matching shields.io ecosystem norms and are not configurable — simplicity over flexibility for a CI-only feature.
+
+**Why a dedicated flag (not `--format badge`):** `--format` implies stdout formatting for human or machine consumption. Badge JSON is a CI artifact written to a file for `schneegans/dynamic-badges-action` to upload to a GitHub Gist. The write-to-file semantics don't match `--format`'s stdout pattern.
+
+**Implementation:** `--badge-json PATH` runs `--summary` calculation internally to get the percentage, writes JSON to the specified path, then proceeds with normal output. Mutually exclusive with `--output` (not `--format` — badge can coexist with terminal output).
+
+### Decision 7: Config Introspection
+
+**Decision:** `docvet config show` via typer command group pattern.
+
+```python
+# In cli.py
+config_app = typer.Typer(help="Configuration commands.")
+app.add_typer(config_app, name="config")
+
+@config_app.command("show")
+def config_show(config_path: ConfigOption = None) -> None:
+    """Display resolved configuration with defaults."""
+    cfg = load_config(config_path)
+    # ... serialize to readable key-value format
+```
+
+**Output format:** TOML-like display of resolved `[tool.docvet]` config with defaults shown. Uses `dataclasses.asdict()` on `DocvetConfig` and formats as readable key-value pairs.
+
+**Rationale:** Users need to verify which config values are active, especially when debugging why a rule fires or doesn't. Typer command group pattern (`add_typer`) is idiomatic — avoids string-dispatch `if action == "show"` anti-pattern.
+
+### Growth Decision Impact Analysis
+
+**Implementation Sequence:**
+1. **Decision 2** (Suppression module) — standalone, no dependencies on other decisions
+2. **Decision 1** (Detection layer extraction) — refactors enrichment, prerequisite for fix
+3. **Decision 3** (Fix + suppression interaction) — depends on Decisions 1 and 2
+4. **Decision 4** (Summary counting) — independent, can parallel with 1-3
+5. **Decision 5** (SARIF formatter) — independent, can parallel with 1-4
+6. **Decision 6** (Badge JSON) — depends on Decision 4 (summary percentage)
+7. **Decision 7** (Config introspection) — independent, lowest priority
+
+**Cross-Decision Dependencies:**
+- Decision 1 → Decision 3 (fix needs detection layer)
+- Decision 2 → Decision 3 (fix needs suppression)
+- Decision 4 → Decision 6 (badge needs summary percentage)
+- Decisions 5, 7 are fully independent
+
+## Growth Phase — Implementation Patterns & Consistency Rules
+
+### Conflict Points Identified
+
+8 areas where AI agents implementing Growth phase features could make inconsistent choices.
+
+### Naming Patterns
+
+**Detection function naming (Decision 1):**
+- Pattern: `_detect_{rule_id_with_underscores}` — mirrors existing `_check_*` naming but with `_detect_` prefix
+- `missing-raises` → `_detect_missing_raises`
+- `missing-attributes` → `_detect_missing_attributes`
+- These live in `checks/_detection.py` (package-private shared module), not in `enrichment.py`
+- **Anti-pattern:** `_find_raises`, `_get_missing_raises`, `_extract_raises` — any prefix other than `_detect_`
+
+**Scaffold function naming (Decision 1):**
+- Pattern: `_scaffold_{section_name_lowercase}` — named after the section being scaffolded, not the rule
+- `missing-raises` → `_scaffold_raises`
+- `missing-attributes` → `_scaffold_attributes`
+- **Anti-pattern:** `_scaffold_missing_raises`, `_fix_raises`, `_generate_raises_section`
+
+**Suppression function naming (Decision 2):**
+- Public API: `filter_suppressed` (batch), `is_suppressed` (single-check)
+- Internal helpers: `_parse_ignore_comment`, `_parse_ignore_file_comment`
+- **Anti-pattern:** `suppress`, `should_ignore`, `is_ignored` — use project-specific terminology
+
+**Fix dispatch table (Decision 1+3):**
+- Pattern: `_FIX_DISPATCH` — mirrors `_RULE_DISPATCH` naming convention
+- Tuple of `(rule_id_str, detect_fn, scaffold_fn)` triples
+- **Anti-pattern:** Dict-based dispatch, class-based dispatch, dynamic dispatch
+
+### Structure Patterns
+
+**New module placement:**
+
+| Module | Location | Public API | Depends On |
+|--------|----------|------------|------------|
+| `_detection.py` | `src/docvet/checks/_detection.py` | None (package-private) | `ast_utils`, `config` |
+| `suppression.py` | `src/docvet/suppression.py` | `filter_suppressed`, `is_suppressed` | `checks._finding.Finding` |
+| `fix.py` | `src/docvet/checks/fix.py` | `fix_enrichment` | `checks._detection`, `suppression.is_suppressed`, `ast_utils` |
+
+- `_detection.py` lives inside `checks/` with underscore prefix — package-private shared module. Both `enrichment.py` and `fix.py` import from it within the same package. This respects Python's underscore convention (no cross-package private imports).
+- `suppression.py` lives at package root (not inside `checks/`) because it operates on findings from all checks, not just one
+- `fix.py` lives inside `checks/` because it's enrichment-specific (scaffolding enrichment sections)
+
+**File organization within `_detection.py`:**
+1. Module docstring
+2. `from __future__ import annotations`
+3. Stdlib imports (`ast`, `re`)
+4. Local imports (`from docvet.ast_utils import Symbol`)
+5. Type aliases (`_NodeT = ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef`)
+6. `_detect_*` functions (4 complex rules, taxonomy-table order)
+
+**File organization within `fix.py`:**
+1. Module docstring
+2. `from __future__ import annotations`
+3. Stdlib imports (`ast`, `re`)
+4. Local imports (from `_detection` import `_detect_*`, from `suppression` import `is_suppressed`)
+5. `_FIX_DISPATCH` table
+6. `_scaffold_*` functions (same taxonomy-table order as enrichment `_check_*`)
+7. Docstring insertion helpers (`_insert_section`, `_compute_indent`)
+8. `fix_enrichment` public orchestrator (last function)
+
+**File organization within `suppression.py`:**
+1. Module docstring
+2. `from __future__ import annotations`
+3. Stdlib imports (`re`)
+4. Local imports (`from docvet.checks._finding import Finding`)
+5. Comment parsing regex constants (`_IGNORE_PATTERN`, `_IGNORE_FILE_PATTERN`)
+6. `_parse_ignore_comment`, `_parse_ignore_file_comment` helpers
+7. `is_suppressed` (single-check interface)
+8. `filter_suppressed` (batch interface, last function)
+
+**Enrichment refactor impact:**
+- `enrichment.py` `_check_*` functions are updated to import and call `_detect_*` from `_detection.py`
+- `_check_*` signatures remain identical — no caller changes
+- `_build_node_index` stays in `enrichment.py` unless fix needs it directly (implementation-time decision)
+- Consider moving `_parse_sections` and `_extract_section_content` to `_detection.py` if fix needs them — evaluate at implementation time
+
+**Test organization:**
+- `tests/unit/test_suppression.py` — suppression module tests
+- `tests/unit/checks/test_fix.py` — fix module tests
+- `tests/unit/checks/test_detection.py` — detection function tests (additive, independent of enrichment tests)
+- Test naming follows existing convention: `test_{function}_when_{condition}_returns_{expected}`
+
+### Suppression Comment Patterns
+
+**Regex patterns for suppression parsing (Decision 2):**
+
+```python
+# Line-level with rule IDs: # docvet: ignore[rule-id] or # docvet: ignore[rule-a,rule-b]
+_IGNORE_PATTERN = re.compile(
+    r"#\s*docvet:\s*ignore\[([^\]]+)\]"
+)
+
+# Line-level bare (all rules): # docvet: ignore
+_IGNORE_BARE_PATTERN = re.compile(
+    r"#\s*docvet:\s*ignore\s*$"
+)
+
+# File-level with rule IDs: # docvet: ignore-file[rule-id]
+_IGNORE_FILE_PATTERN = re.compile(
+    r"#\s*docvet:\s*ignore-file\[([^\]]+)\]"
+)
+
+# File-level bare (all rules): # docvet: ignore-file
+_IGNORE_FILE_BARE_PATTERN = re.compile(
+    r"#\s*docvet:\s*ignore-file\s*$"
+)
+```
+
+- Whitespace is lenient around `docvet:` (matches `# docvet:` and `#docvet:`)
+- Rule IDs inside brackets are comma-separated, stripped of whitespace
+- **Anti-pattern:** Supporting `# noqa` style (not our syntax), `# type: ignore` style (different tool)
+
+**Line matching for symbol suppression:**
+- Match against the **same line** as the symbol's `def`/`class` keyword only (i.e., `symbol.line`). This is the simplest, least ambiguous rule — the comment must be on the definition line itself.
+- File-level comments (`ignore-file`) match against any line in the file.
+- **Anti-pattern:** Matching against the line above (ambiguous with blank lines), matching against the docstring line, matching against all lines in the function body, scanning decorator lines
+
+### Scaffold Construction Patterns
+
+**Docstring section scaffolding format (Decision 1):**
+
+```python
+# Standard indentation: 4 spaces (matches Google style)
+def _scaffold_raises(exceptions: list[str]) -> str:
+    return "Raises:\n" + "".join(f"    {e}: ...\n" for e in exceptions)
+
+def _scaffold_attributes(fields: list[str]) -> str:
+    return "Attributes:\n" + "".join(f"    {f}: ...\n" for f in fields)
+```
+
+- Section header at base indent level (matching surrounding docstring sections)
+- Items indented 4 spaces from the section header
+- Placeholder `...` for descriptions (user fills in)
+- Trailing newline on each item
+- **Anti-pattern:** Using `TODO` as placeholder, guessing descriptions, using 2-space indent
+
+**Docstring insertion position:**
+- New sections are inserted before the closing `"""` triple-quote
+- If existing sections are present, insert **after the last existing section**, regardless of existing section order. Fix scaffolds missing sections — it does not reorder existing ones.
+- **Blank line separator:** If the docstring contains only a summary line (no blank line separator between summary and body), fix inserts `\n\n` before the scaffolded section. This ensures valid Google-style structure: summary → blank line → sections.
+- **Anti-pattern:** Inserting at the top of the docstring, inserting between existing sections out of order, reordering existing sections
+
+### SARIF Construction Patterns
+
+**SARIF v2.1.0 envelope (Decision 5):**
+
+```python
+{
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [{
+        "tool": {
+            "driver": {
+                "name": "docvet",
+                "version": "...",  # from importlib.metadata
+                "rules": [...]     # unique rules from findings
+            }
+        },
+        "results": [...]  # one per finding
+    }]
+}
+```
+
+- Exactly one run per SARIF document
+- Version string from `importlib.metadata.version("docvet")`
+- Rules array is deduplicated (each unique `rule_id` appears once)
+- **Anti-pattern:** Multiple runs, hardcoded version strings, duplicate rule entries
+
+### Growth Enforcement Guidelines
+
+**All AI agents implementing Growth features MUST:**
+
+1. Place `_detect_*` functions in `checks/_detection.py` — never in `enrichment.py` or `fix.py`
+2. Use `_scaffold_*` prefix for scaffold functions in `fix.py` — named after section, not rule
+3. Never import from `cli.py` in non-CLI modules — `suppression.py` and `fix.py` must be CLI-independent
+4. Maintain taxonomy-table ordering in all dispatch tables (`_RULE_DISPATCH`, `_FIX_DISPATCH`)
+5. Use `Finding.file` for suppression file reads — never accept file paths as a separate parameter to `filter_suppressed`
+6. Preserve all 415 existing enrichment tests unchanged — detection extraction is a refactor, not a rewrite
+7. Suppression line matching: same-line only for `ignore[]`, any-line for `ignore-file[]`
+8. Insert scaffolded sections after the last existing section — never reorder
+
+## Growth Phase — Project Structure & Boundaries
+
+### New Files for Growth Phase
+
+Existing files shown as-is. **New files** marked with `← NEW`, modified files with `← MODIFIED`.
+
+```
+src/docvet/
+├── __init__.py
+├── cli.py                    ← MODIFIED (config subcommand, --summary, --badge-json, SARIF format, fix file write)
+├── config.py
+├── discovery.py
+├── ast_utils.py
+├── reporting.py              ← MODIFIED (format_sarif added)
+├── suppression.py            ← NEW (filter_suppressed, is_suppressed)
+├── lsp.py
+└── checks/
+    ├── __init__.py            ← MODIFIED (re-export fix_enrichment)
+    ├── _finding.py
+    ├── _detection.py          ← NEW (_detect_*, _parse_sections, _build_node_index)
+    ├── enrichment.py          ← MODIFIED (imports _detect_*, _parse_sections, _build_node_index from _detection)
+    ├── fix.py                 ← NEW (fix_enrichment + _scaffold_* functions)
+    ├── freshness.py
+    ├── coverage.py
+    ├── griffe_compat.py
+    └── presence.py
+
+tests/
+├── unit/
+│   ├── test_suppression.py    ← NEW
+│   └── checks/
+│       ├── test_detection.py  ← NEW
+│       ├── test_fix.py        ← NEW
+│       ├── test_enrichment.py # Unchanged (415 tests preserved)
+│       └── ...
+└── fixtures/
+    ├── suppression_*.py       ← NEW (files with ignore comments)
+    └── ...
+```
+
+### Growth Architectural Boundaries
+
+**Public API additions:**
+
+| Module | New Public API | Consumers |
+|--------|---------------|-----------|
+| `suppression.py` | `filter_suppressed(findings)`, `is_suppressed(line, rule, source)` | `cli.py`, `checks/fix.py` |
+| `checks/fix.py` | `fix_enrichment(source, tree, config, file_path) -> str` | `cli.py` |
+| `reporting.py` | `format_sarif(findings, file_count)` | `cli.py` |
+
+**Module dependency additions:**
+
+```
+cli.py
+  → imports fix_enrichment from docvet.checks.fix         ← NEW
+  → imports filter_suppressed from docvet.suppression      ← NEW
+  → imports format_sarif from docvet.reporting             ← NEW
+  → handles file write for fix (reads file, calls fix_enrichment, writes result)
+
+checks/fix.py                                              ← NEW
+  → imports _detect_* from docvet.checks._detection
+  → imports _parse_sections, _build_node_index from docvet.checks._detection
+  → imports is_suppressed from docvet.suppression
+  → imports Symbol, get_documented_symbols from docvet.ast_utils
+  → imports EnrichmentConfig from docvet.config
+  → NEVER imports from docvet.cli
+  → PURE FUNCTION: receives source string, returns modified source string (no file I/O)
+
+checks/_detection.py                                       ← NEW
+  → imports Symbol from docvet.ast_utils
+  → ZERO config dependency — _detect_* functions detect unconditionally; gating is caller's job
+  → NEVER imports from docvet.cli, docvet.config, docvet.checks.enrichment, or docvet.suppression
+
+checks/enrichment.py                                       ← MODIFIED
+  → imports _detect_* from docvet.checks._detection        ← NEW IMPORT
+  → imports _parse_sections, _build_node_index from docvet.checks._detection  ← MOVED
+  → all other imports unchanged
+
+suppression.py                                             ← NEW
+  → imports Finding from docvet.checks._finding
+  → NEVER imports from docvet.cli or any check module
+```
+
+**Dependency graph is tree-shaped (no cycles):**
+
+```
+cli.py → checks/fix.py → checks/_detection.py → ast_utils.py
+                        → suppression.py → checks/_finding.py
+       → checks/enrichment.py → checks/_detection.py → ast_utils.py
+       → suppression.py
+       → reporting.py
+```
+
+**Data boundaries:**
+- `_detection.py` — pure functions, no I/O, no file reads, no config dependency
+- `fix.py` — pure function: receives `source: str`, returns modified `source: str`. No file I/O. CLI handles reading and writing files.
+- `suppression.py` — `is_suppressed` is pure (receives source string). `filter_suppressed` reads files via `Finding.file` paths (batch mode I/O).
+- `enrichment.py` — remains pure (no I/O), unchanged behavior
+
+### Requirements to Structure Mapping
+
+**Epic → File Mapping:**
+
+| Epic | Story Area | Primary Files | Supporting Files |
+|------|-----------|---------------|-----------------|
+| 31 — Quick Wins | Fix command | `checks/fix.py`, `checks/_detection.py` | `enrichment.py` (refactored) |
+| 31 — Quick Wins | Inline suppression | `suppression.py` | `cli.py` (pipeline integration) |
+| 31 — Quick Wins | `--summary` flag | `cli.py` | `reporting.py` |
+| 31 — Quick Wins | `config show` | `cli.py` | `config.py` |
+| 32 — Lifecycle | Dynamic badge | `cli.py` | — |
+| 32 — Lifecycle | SARIF output | `reporting.py` | `cli.py` (format dispatch) |
+| 32 — Lifecycle | VS Code extension | Separate repo (`docvet-vscode`) | No core changes |
+| 33 — Visibility | Flagship OSS runs | Docs site only (`docs/`) | No core changes |
+
+### `_detection.py` Contents
+
+Shared detection infrastructure moved from `enrichment.py`:
+
+| Function | Origin | Used By |
+|----------|--------|---------|
+| `_parse_sections(docstring) -> set[str]` | Was in `enrichment.py` | `enrichment.py`, `fix.py` |
+| `_build_node_index(tree) -> dict[int, _NodeT]` | Was in `enrichment.py` | `enrichment.py`, `fix.py` |
+| `_detect_missing_raises(symbol, node_index) -> list[str]` | Extracted from `_check_missing_raises` | `enrichment.py`, `fix.py` |
+| `_detect_missing_attributes(symbol, node_index, file_path) -> list[str]` | Extracted from `_check_missing_attributes` | `enrichment.py`, `fix.py` |
+| `_detect_missing_warns(symbol, node_index) -> list[str]` | Extracted from `_check_missing_warns` | `enrichment.py`, `fix.py` |
+| `_detect_missing_other_parameters(symbol, node_index) -> list[str]` | Extracted from `_check_missing_other_parameters` | `enrichment.py`, `fix.py` |
+
+Note: Helper functions used only by `_detect_*` (e.g., `_is_dataclass`, `_is_namedtuple`, `_extract_exception_name`) also move to `_detection.py`.
+
+### Growth Data Flow
+
+**Fix command flow:**
+
+```
+CLI (docvet fix)
+  │
+  │  reads file → source: str
+  │  ast.parse(source) → tree: ast.Module
+  │  loads config → config.enrichment: EnrichmentConfig
+  │
+  ▼
+fix_enrichment(source, tree, config, file_path) → modified_source: str
+  │
+  │  get_documented_symbols(tree) → symbols
+  │  _build_node_index(tree) → node_index
+  │
+  │  For each symbol:
+  │    _parse_sections(docstring) → sections
+  │    For each (rule_id, detect_fn, scaffold_fn) in _FIX_DISPATCH:
+  │      is_suppressed(symbol.line, rule_id, source) → skip if True
+  │      detect_fn(symbol, node_index) → evidence
+  │      scaffold_fn(evidence) → section text
+  │      _insert_section(source, symbol, section_text) → modified source
+  │
+  ▼
+CLI writes modified_source back to file
+```
+
+**Suppression pipeline flow:**
+
+```
+_output_and_exit(ctx, findings_by_check, config, ...)
+  │
+  │  1. Resolve no_color
+  │  2. Flatten findings → all_findings
+  │  2.5 filter_suppressed(all_findings) → filtered_findings  ← NEW STEP
+  │  3. Verbose header (if multi-check)
+  │  4. Verbose coverage line
+  │  5. Resolve format, emit findings, exit
+```
+
+## Growth Phase — Architecture Validation
+
+### Coherence Validation
+
+**Decision Compatibility:** All 7 decisions are internally consistent. No technology conflicts (all stdlib Python, no new deps). Decision 1 (detection) feeds Decision 3 (fix+suppression) cleanly via `_detection.py`. Decision 2 (suppression) dual interface serves both pipeline and fix. Decision 4 (summary) → Decision 6 (badge) dependency is one-directional. Decisions 5 (SARIF) and 7 (config) are fully independent.
+
+**Pattern Consistency:** All naming patterns follow existing conventions (`_detect_*`, `_scaffold_*`, `_check_*`). Dispatch table pattern (`_FIX_DISPATCH`) mirrors `_RULE_DISPATCH`. Finding construction pattern unchanged. File organization mirrors v1.0 structure.
+
+**Structure Alignment:** Tree-shaped dependency graph with no cycles. `_detection.py` as package-private shared module respects underscore convention. Pure function pattern preserved for `fix_enrichment`. Suppression at package root (not in `checks/`) — correct for cross-check scope.
+
+### Requirements Coverage Validation
+
+**FR Coverage (25 FRs):**
+
+| FR | Architectural Support | Decision |
+|----|----------------------|----------|
+| FR1 (badge JSON) | `--badge-json PATH` flag | Decision 6 |
+| FR2-3 (--summary) | Parallel `symbols_by_check` dict | Decision 4 |
+| FR4-5 (config show) | `config show` typer command group | Decision 7 |
+| FR6-9, FR12 (fix core) | `_detect_*` → `_scaffold_*` pipeline | Decision 1 |
+| FR10-11 (fix CLI) | CLI flags, reuses `discover_files` | Structure |
+| FR13 (line ignore + rule) | `_IGNORE_PATTERN` regex | Decision 2 |
+| FR14 (line ignore all) | `_IGNORE_BARE_PATTERN` regex | Decision 2 (amended) |
+| FR15 (file ignore + rule) | `_IGNORE_FILE_PATTERN` regex | Decision 2 |
+| FR16 (file ignore all) | `_IGNORE_FILE_BARE_PATTERN` regex | Decision 2 (amended) |
+| FR17 (verbose suppressed) | Pipeline logs filtered count | Decision 2 |
+| FR18 (post-filter) | `filter_suppressed` in step 2.5 | Decision 2 |
+| FR19-20 (VS Code) | Separate repo, deferred | — |
+| FR21-22 (SARIF) | `format_sarif` in reporting.py | Decision 5 |
+| FR23-25 (flagship) | Docs-only, no core changes | — |
+
+**NFR Coverage (10 NFRs):** All covered. NFR5 uses regex instead of tokenize (simpler, equivalent correctness — valid deviation from suggested approach).
+
+### Gap Analysis
+
+**One gap found and resolved:** FR14/FR16 (bare ignore without brackets) conflicted with Decision 2's original position. **Amended** Decision 2 to support bare `# docvet: ignore` and `# docvet: ignore-file` (all rules), matching ruff's `# noqa` convention. Added `_IGNORE_BARE_PATTERN` and `_IGNORE_FILE_BARE_PATTERN` regexes to patterns section.
+
+**No other gaps found.**
+
+### Architecture Completeness Checklist
+
+**Requirements Analysis**
+- [x] Project context analyzed (25 FRs, 10 NFRs from epics document; 30 FRs, 10 NFRs from PRD)
+- [x] Scale and complexity assessed (3 new modules, brownfield)
+- [x] Technical constraints identified (zero deps, no Finding changes, no return type changes)
+- [x] Cross-cutting concerns mapped (5 party-mode findings → 3 party reviews → 21 total findings addressed)
+
+**Architectural Decisions**
+- [x] 7 decisions documented with code examples, rationale, and anti-patterns
+- [x] Per-rule detection return types specified
+- [x] Module boundaries explicit with dependency directions
+- [x] Implementation sequence with cross-decision dependencies
+
+**Implementation Patterns**
+- [x] Naming conventions for `_detect_*`, `_scaffold_*`, suppression functions
+- [x] Structure patterns for `_detection.py`, `fix.py`, `suppression.py`
+- [x] Suppression comment regexes (4 patterns: line+rule, line+bare, file+rule, file+bare)
+- [x] Scaffold construction with edge cases (blank lines, insertion position, section ordering)
+
+**Project Structure**
+- [x] Directory tree with new/modified files marked
+- [x] Module dependency graph (tree-shaped, verified cycle-free)
+- [x] Data boundaries per module (pure vs. I/O)
+- [x] Epic-to-file mapping for all 3 epics
+
+### Growth Architecture Readiness Assessment
+
+**Overall Status:** READY FOR IMPLEMENTATION
+
+**Confidence Level:** High — brownfield project with proven patterns, 3 party-mode reviews surfaced and resolved 21 findings, all existing tests (737) unaffected.
+
+**Key Strengths:**
+- Shared `_detection.py` module cleanly separates detection from formatting
+- Pure function pattern preserved throughout (fix, detection, enrichment)
+- Suppression dual-interface (batch + single) serves both pipeline and fix
+- Tree-shaped dependency graph — zero circular import risk
+- 415 existing enrichment tests preserved unchanged via black-box refactor
+
+**Implementation Sequence:**
+1. Decision 2 (Suppression) — standalone foundation
+2. Decision 1 (Detection extraction + enrichment refactor) — highest risk, isolated
+3. Decision 3 (Fix command) — depends on 1 + 2
+4. Decision 4 (Summary) — independent, can parallel with 1-3
+5. Decision 5 (SARIF) — independent, can parallel with 1-4
+6. Decision 6 (Badge) — depends on 4
+7. Decision 7 (Config show) — independent, lowest priority

--- a/_bmad-output/planning-artifacts/epics-quick-wins-lifecycle-visibility.md
+++ b/_bmad-output/planning-artifacts/epics-quick-wins-lifecycle-visibility.md
@@ -1,0 +1,461 @@
+---
+stepsCompleted: [1, 2, 3, 4]
+inputDocuments:
+  - "GitHub Issue #256: Dynamic docvet badge"
+  - "GitHub Issue #305: docvet fix command"
+  - "GitHub Issue #306: --summary flag"
+  - "GitHub Issue #308: Inline suppression comments"
+  - "GitHub Issue #309: config --show-defaults"
+  - "GitHub Issue #160: VS Code extension"
+  - "GitHub Issue #163: SARIF output format"
+  - "GitHub Issue #164: Flagship OSS runs"
+  - "GitHub Issue #158: Example project template"
+  - "GitHub Issue #265: Architecture diagrams"
+  - "GitHub Issue #310: Incomplete section detection (exploration)"
+  - "Party-mode consensus (2026-03-06): Epic 31-34 structure"
+  - "PRD Growth items audit (2026-03-06)"
+---
+
+# docvet - Epic Breakdown (Epics 31-34)
+
+## Overview
+
+This document provides the epic and story breakdown for docvet's post-v1.0 growth phase (Epics 31-34), decomposing GitHub issues, PRD Growth items, and party-mode consensus into implementable stories. All v1.0 PRD requirements (FR1-FR127, NFR1-NFR66) are fully satisfied. This wave targets adoption, conversion, and platform expansion.
+
+## Requirements Inventory
+
+### Functional Requirements
+
+FR1: Dynamic badge endpoint writes shields.io-compatible JSON (pass/fail/findings count) to a GitHub Gist after each CI run (#256)
+FR2: `--summary` flag prints per-check quality percentages and overall score alongside normal output (#306)
+FR3: Summary output works with `--format json` for machine consumption (#306)
+FR4: `docvet config --show-defaults` prints effective merged configuration in TOML format (#309)
+FR5: Config show-defaults distinguishes user-configured values from built-in defaults (#309)
+FR6: `docvet fix` generates missing docstring sections from pure AST analysis (#305)
+FR7: Fix is deterministic — same input always produces same output (#305)
+FR8: Fix is idempotent — running twice produces no additional changes (#305)
+FR9: Fix preserves existing docstring content byte-for-byte (#305)
+FR10: Fix supports `--dry-run` showing diff without modifying files (#305)
+FR11: Fix supports all file discovery modes (diff, staged, all, positional args) (#305)
+FR12: Fix scaffolds Args, Returns, Raises, Yields, Receives, Warns, Attributes, Examples sections (#305)
+FR13: Line-level suppression via `# docvet: ignore[rule-id]` on def/class line (#308)
+FR14: Line-level suppression via `# docvet: ignore` (all rules) on def/class line (#308)
+FR15: File-level suppression via `# docvet: ignore-file[rule-id]` at top of file (#308)
+FR16: File-level suppression via `# docvet: ignore-file` (all rules) at top of file (#308)
+FR17: Suppressed findings reported in verbose mode for transparency (#308)
+FR18: Suppression implemented as post-filter on findings list, not per-check modification (#308)
+FR19: VS Code extension launches `docvet lsp` via STDIO and publishes diagnostics to Problems panel (#160)
+FR20: VS Code extension contributes Language Model Tools for Copilot agent mode (#160)
+FR21: `--format sarif` produces SARIF v2.1.0 compliant output with rule definitions and locations (#163)
+FR22: SARIF output compatible with `github/codeql-action/upload-sarif@v3` (#163)
+FR23: Flagship OSS runs produce documented findings on 3+ major projects (FastAPI, Pydantic, typer) (#164)
+FR24: Flagship results published as docs page or blog post (#164)
+FR25: Example project template shows full docvet + mkdocstrings pipeline (#158)
+
+### NonFunctional Requirements
+
+NFR1: Badge JSON endpoint uses shields.io schema v1 (`schemaVersion`, `label`, `message`, `color`)
+NFR2: Summary percentage calculation: `(symbols_checked - symbols_with_findings) / symbols_checked`
+NFR3: Fix command adds zero runtime dependencies — AST-only, stdlib
+NFR4: Fix insertion uses AST line numbers for positioning — no libcst dependency
+NFR5: Suppression comment parsing uses tokenize module or AST comment extraction
+NFR6: Suppression syntax follows established conventions (`# tool: directive[args]`)
+NFR7: VS Code extension is a thin LSP wrapper — minimal TypeScript, no bundled Python
+NFR8: SARIF output reuses ~60% of existing JSON formatter code
+NFR9: All new features maintain zero-dependency core (typer only)
+NFR10: All new subcommands follow existing CLI patterns (`_output_and_exit` pipeline)
+
+### Additional Requirements
+
+- Party-mode consensus (2026-03-06): unanimous 17/17 agent agreement on epic sequencing
+- Epic 31 ships first as quick wins (days, not weeks)
+- Fix command requires architecture spike before full implementation
+- Incomplete section detection (#310) requires exploration spike before committing
+- Example project (#158) can fold into flagship runs (#164) as a single deliverable
+- Architecture diagrams (#265) are lowest priority — contributor DX only
+- Parking lot items (#148, #72, #307) tracked but not committed
+
+### FR Coverage Map
+
+FR1:  Epic 31, Story 31.1 - Dynamic badge endpoint (shields.io JSON to Gist)
+FR2:  Epic 31, Story 31.2 - --summary flag with per-check percentages
+FR3:  Epic 31, Story 31.2 - Summary works with --format json
+FR4:  Epic 31, Story 31.3 - config --show-defaults in TOML format
+FR5:  Epic 31, Story 31.3 - Config distinguishes defaults vs user-configured
+FR6:  Epic 32, Story 32.2 - docvet fix generates missing sections from AST
+FR7:  Epic 32, Story 32.2 - Fix is deterministic
+FR8:  Epic 32, Story 32.2 - Fix is idempotent
+FR9:  Epic 32, Story 32.2 - Fix preserves existing content
+FR10: Epic 32, Story 32.3 - Fix supports --dry-run
+FR11: Epic 32, Story 32.3 - Fix supports all discovery modes
+FR12: Epic 32, Story 32.2 - Fix scaffolds all section types
+FR13: Epic 32, Story 32.4 - Line-level ignore with rule ID
+FR14: Epic 32, Story 32.4 - Line-level ignore all rules
+FR15: Epic 32, Story 32.4 - File-level ignore with rule ID
+FR16: Epic 32, Story 32.4 - File-level ignore all rules
+FR17: Epic 32, Story 32.4 - Suppressed findings in verbose mode
+FR18: Epic 32, Story 32.4 - Suppression as post-filter
+FR19: Epic 33, Story 33.1 - VS Code extension with LSP
+FR20: Epic 33, Story 33.1 - VS Code Language Model Tools for Copilot
+FR21: Epic 33, Story 33.3 - SARIF v2.1.0 output format
+FR22: Epic 33, Story 33.3 - SARIF compatible with codeql upload action
+FR23: Epic 33, Story 33.2 - Flagship runs on 3+ major projects
+FR24: Epic 33, Story 33.2 - Flagship results published
+FR25: Epic 33, Story 33.2 - Example project (folded into flagship runs)
+
+## Epic List
+
+### Epic 31: Project Health Visibility
+Users can see at-a-glance docstring quality metrics, display a dynamic badge on their README, and inspect their effective configuration -- giving them a complete picture of their project's documentation health without digging through individual findings.
+**FRs covered:** FR1, FR2, FR3, FR4, FR5
+**NFRs covered:** NFR1, NFR2, NFR10
+
+### Epic 32: Linter Lifecycle -- Fix & Suppress
+Users can automatically scaffold missing docstring sections with `docvet fix` and selectively suppress findings for intentional deviations with inline comments -- completing the linter lifecycle from detection through resolution.
+**FRs covered:** FR6, FR7, FR8, FR9, FR10, FR11, FR12, FR13, FR14, FR15, FR16, FR17, FR18
+**NFRs covered:** NFR3, NFR4, NFR5, NFR6, NFR10
+
+### Epic 33: Ecosystem Visibility & Editor Integration
+Users can see docvet findings directly in VS Code, validate docvet against flagship OSS projects for social proof, access a reference example showing the full pipeline, and upload findings to GitHub Code Scanning via SARIF.
+**FRs covered:** FR19, FR20, FR21, FR22, FR23, FR24, FR25
+**NFRs covered:** NFR7, NFR8
+
+### Deferred (Post-Epic 33 Candidates)
+Reassess after Epic 33 ships based on user demand and landscape changes.
+- #310: Incomplete section detection (exploration spike)
+- #265: Architecture Mermaid diagrams
+- #148: Negation pattern support in exclude
+- #72: WebMCP integration
+- #307: Ruff plugin exploration
+
+## Epic 31: Project Health Visibility
+
+Users can see at-a-glance docstring quality metrics, display a dynamic badge on their README, and inspect their effective configuration -- giving them a complete picture of their project's documentation health without digging through individual findings.
+
+### Story 31.1: Dynamic Badge Endpoint
+
+As a **project maintainer**,
+I want a dynamic badge that shows my docvet pass/fail status and findings count,
+So that my README communicates documentation health at a glance and encourages adoption.
+
+**Acceptance Criteria:**
+
+**Given** the docvet GitHub Action runs in CI
+**When** the check completes with zero findings
+**Then** a shields.io-compatible JSON file is written to a GitHub Gist with `{"schemaVersion":1, "label":"docvet", "message":"passing", "color":"brightgreen"}`
+
+**Given** the docvet GitHub Action runs in CI
+**When** the check completes with findings
+**Then** the JSON file shows `"message":"N findings"` with color `"yellow"` (warnings only) or `"red"` (failures)
+
+**Given** a user configures `shields.io/endpoint?url=<gist-raw-url>` in their README
+**When** the badge renders
+**Then** it displays the current pass/fail status from the latest CI run
+
+**Given** the `schneegans/dynamic-badges-action` step is added to the GitHub Action workflow
+**When** the Gist does not yet exist
+**Then** the action creates it using the configured `GIST_SECRET` token
+
+### Story 31.2: Summary Flag for Quality Percentages
+
+As a **developer**,
+I want a `--summary` flag that prints per-check quality percentages,
+So that I can quickly assess my project's overall documentation health without reading individual findings.
+
+**Acceptance Criteria:**
+
+**Given** a codebase with mixed findings across checks
+**When** the user runs `docvet check --all --summary`
+**Then** output includes files scanned, symbols checked, per-check percentages (enrichment, freshness, coverage, griffe), and an overall score
+
+**Given** the `--summary` flag is used with `--format json`
+**When** the check completes
+**Then** summary data is included in the JSON output as a `summary` object with numeric fields
+
+**Given** the `--summary` flag is used with a subcommand (e.g., `docvet enrichment --summary`)
+**When** the check completes
+**Then** only the relevant check's percentage is shown
+
+**Given** a codebase with zero findings
+**When** `--summary` is used
+**Then** all percentages show 100% and overall score is 100%
+
+**Given** the percentage calculation
+**When** computed
+**Then** the formula is `(symbols_checked - symbols_with_findings) / symbols_checked * 100`, rounded to nearest integer
+
+**Given** the summary needs a total symbol count
+**When** computed
+**Then** the count is derived from `get_documented_symbols()` calls already in the check pipeline, not from a separate AST pass
+
+### Story 31.3: Config Show-Defaults Command
+
+As a **developer**,
+I want a `docvet config --show-defaults` command that prints my effective configuration,
+So that I can debug why specific rules are running and onboard onto available settings.
+
+**Acceptance Criteria:**
+
+**Given** a project with no `[tool.docvet]` in pyproject.toml
+**When** the user runs `docvet config --show-defaults`
+**Then** all built-in defaults are printed in TOML format, suitable for copy-paste into pyproject.toml
+
+**Given** a project with partial `[tool.docvet]` configuration
+**When** the user runs `docvet config --show-defaults`
+**Then** the merged effective config is printed, with comments indicating which values are user-configured vs defaults
+
+**Given** the user runs `docvet config --show-defaults --format json`
+**When** output is produced
+**Then** the effective config is printed as a JSON object
+
+**Given** no pyproject.toml exists in the current directory or parents
+**When** `docvet config --show-defaults` is run
+**Then** all defaults are printed with a note that no config file was found
+
+## Epic 32: Linter Lifecycle -- Fix & Suppress
+
+Users can automatically scaffold missing docstring sections with `docvet fix` and selectively suppress findings for intentional deviations with inline comments -- completing the linter lifecycle from detection through resolution.
+
+### Story 32.1: Fix Feasibility Spike
+
+As a **project maintainer**,
+I want confidence that AST-based docstring insertion works reliably,
+So that the fix command can be built on a validated foundation.
+
+**Acceptance Criteria:**
+
+**Given** a Python function with a one-line docstring and missing Raises/Args sections
+**When** the spike's proof-of-concept inserts scaffolded sections using AST line numbers
+**Then** the modified file is valid Python and `docvet check` produces zero findings for the scaffolded sections
+
+**Given** a function with an existing multi-section docstring (Args exists, Raises missing)
+**When** the spike inserts the missing Raises section
+**Then** existing Args content is preserved byte-for-byte and Raises is inserted after the last existing section
+
+**Given** the spike runs insertion twice on the same file
+**When** the second run executes
+**Then** no changes are made (idempotency validated)
+
+**Given** the spike results
+**When** reviewed
+**Then** a decision document records: chosen insertion strategy (string ops + AST line numbers vs libcst), edge cases identified, and go/no-go recommendation
+
+### Story 32.2: Fix Core -- Section Scaffolding Engine
+
+As a **developer**,
+I want `docvet fix` to generate missing docstring sections from AST analysis,
+So that I get a skeleton I can fill in instead of writing sections from scratch.
+
+**Acceptance Criteria:**
+
+**Given** a function with missing Args, Returns, and Raises sections
+**When** `docvet fix` runs on the file
+**Then** all three sections are scaffolded with parameter names from the signature and exception names from the body, using `[TODO: describe]` placeholders
+
+**Given** a function that already has an Args section but is missing Raises
+**When** `docvet fix` runs
+**Then** only the Raises section is added; existing Args content is preserved byte-for-byte
+
+**Given** a class with missing Attributes section (dataclass/NamedTuple/TypedDict)
+**When** `docvet fix` runs
+**Then** an Attributes section is scaffolded listing all fields from the class definition
+
+**Given** a generator function missing Yields and Receives sections
+**When** `docvet fix` runs
+**Then** both sections are scaffolded with `[TODO: describe]` placeholders
+
+**Given** a symbol missing an Examples section (and `require_examples` config matches its type)
+**When** `docvet fix` runs
+**Then** an Examples section is scaffolded with `>>> ` placeholder
+
+**Given** fix produces output
+**When** the same input is processed
+**Then** output is deterministic (same input = same output, always)
+
+**Given** fix has already run on a file
+**When** fix runs again on the same file
+**Then** no changes are made (idempotent)
+
+**Given** a file with mixed symbols -- some needing fixes, some already complete
+**When** `docvet fix` runs
+**Then** only symbols with missing sections are modified; complete symbols are untouched
+
+### Story 32.3: Fix CLI Wiring -- Subcommand, Dry-Run, and Discovery
+
+As a **developer**,
+I want the fix command integrated into the CLI with dry-run and file discovery support,
+So that I can preview changes before applying them and use fix with the same workflows as check.
+
+**Acceptance Criteria:**
+
+**Given** the user runs `docvet fix --dry-run`
+**When** files have missing sections
+**Then** a unified diff is printed to stdout showing what would change, without modifying any files
+
+**Given** the user runs `docvet fix` (no flags)
+**When** files in the git diff have missing sections
+**Then** those files are modified in-place with scaffolded sections
+
+**Given** the user runs `docvet fix --staged`
+**When** staged files have missing sections
+**Then** only staged files are modified
+
+**Given** the user runs `docvet fix --all`
+**When** the codebase has files with missing sections
+**Then** all matching files are modified
+
+**Given** the user runs `docvet fix path/to/file.py`
+**When** the specified file has missing sections
+**Then** only that file is modified
+
+**Given** the user runs `docvet fix` on a file with no missing sections
+**When** fix completes
+**Then** no files are modified and a message indicates "No fixes needed"
+
+**Given** fix modifies files
+**When** the user subsequently runs `docvet check` on those files
+**Then** the scaffolded sections produce zero enrichment findings (roundtrip validation)
+
+### Story 32.4: Inline Suppression Comments
+
+As a **developer**,
+I want to suppress specific docvet findings with inline comments,
+So that I can mark intentional deviations without disabling rules globally.
+
+**Acceptance Criteria:**
+
+**Given** a function definition with `# docvet: ignore[missing-raises]` on the `def` line
+**When** `docvet check` runs
+**Then** any `missing-raises` finding for that symbol is suppressed from output
+
+**Given** a function with `# docvet: ignore[missing-raises,missing-yields]` (comma-separated)
+**When** `docvet check` runs
+**Then** both `missing-raises` and `missing-yields` findings are suppressed for that symbol
+
+**Given** a function with `# docvet: ignore` (no rule specified)
+**When** `docvet check` runs
+**Then** all findings for that symbol are suppressed
+
+**Given** a file with `# docvet: ignore-file[missing-examples]` before the first class/function definition
+**When** `docvet check` runs on that file
+**Then** all `missing-examples` findings in the entire file are suppressed
+
+**Given** a file with `# docvet: ignore-file` (no rule specified) before the first class/function definition
+**When** `docvet check` runs
+**Then** all findings in the entire file are suppressed
+
+**Given** suppressed findings exist and `--verbose` is active
+**When** output is rendered
+**Then** suppressed findings are listed separately with a note indicating suppression reason
+
+**Given** the suppression filter
+**When** implemented
+**Then** it operates as a post-filter on the findings list -- no `_check_*` functions are modified
+
+**Given** an invalid rule ID in a suppression comment (e.g., `# docvet: ignore[nonexistent-rule]`)
+**When** `docvet check` runs
+**Then** a warning is emitted that the rule ID is not recognized
+
+## Epic 33: Ecosystem Visibility & Editor Integration
+
+Users can see docvet findings directly in VS Code, validate docvet against flagship OSS projects for social proof, access a reference example showing the full pipeline, and upload findings to GitHub Code Scanning via SARIF.
+
+### Story 33.1: VS Code Extension
+
+As a **VS Code user**,
+I want a docvet extension that shows docstring findings in the Problems panel,
+So that I see quality issues inline while editing without switching to the terminal.
+
+**Acceptance Criteria:**
+
+**Given** the docvet VS Code extension is installed and a Python file is open
+**When** the file contains symbols with docstring findings
+**Then** diagnostics appear in the Problems panel with rule ID, message, file, and line number
+
+**Given** the extension activates
+**When** it launches the language server
+**Then** it starts `docvet lsp --stdio` as a subprocess and connects via STDIO
+
+**Given** the user edits a Python file and saves
+**When** the LSP server re-analyzes the file
+**Then** diagnostics update in real-time to reflect the current state
+
+**Given** the extension is published to VS Code Marketplace
+**When** a user searches "docvet"
+**Then** the extension appears with proper metadata (description, icon, categories)
+
+**Given** the extension contributes Language Model Tools
+**When** a user asks Copilot agent mode about docstring quality
+**Then** Copilot can invoke `docvet.check` as a tool and return findings contextually
+
+**Given** the user does not have docvet installed
+**When** the extension activates
+**Then** a helpful error message explains how to install docvet (`pip install docvet`)
+
+**Given** the VS Code extension needs a separate repository
+**When** the story begins
+**Then** a `docvet-vscode` repo is created with package.json, extension.ts, and CI for VS Code Marketplace publishing
+
+### Story 33.2: Flagship OSS Runs & Example Guide
+
+As a **potential adopter**,
+I want to see docvet findings on real-world projects I know,
+So that I can evaluate whether docvet finds genuine issues and is worth adopting.
+
+**Acceptance Criteria:**
+
+**Given** docvet is run against FastAPI, Pydantic, and typer (or 3+ comparable Google-style mkdocs projects)
+**When** `docvet check --all` completes on each
+**Then** findings are documented with counts by rule, notable examples, and false positive assessment
+
+**Given** findings are genuine and fixable
+**When** small PRs (5-10 fixes each) are opened on target projects
+**Then** PRs credit docvet and link to the docs site, demonstrating the fix workflow
+
+**Given** the findings data is compiled
+**When** published
+**Then** a docs page or blog post titled "What we found running docvet on the Python ecosystem" is live on the docs site
+
+**Given** a user wants to replicate the docvet + mkdocstrings pipeline
+**When** they visit the flagship results page
+**Then** configuration snippets (mkdocs.yml, pyproject.toml) and a step-by-step guide are included
+
+**Given** the guide content
+**When** a user follows the steps
+**Then** they can configure docvet + mkdocstrings on their own project and verify with `docvet check --all`
+
+**Given** docvet produces findings on a flagship project
+**When** findings are reviewed
+**Then** false positive rate is documented and any false positives are filed as bugs against docvet
+
+### Story 33.3: SARIF Output Format
+
+As a **CI/CD engineer**,
+I want `--format sarif` output for GitHub Code Scanning integration,
+So that docvet findings appear in the Security tab and PR annotations without custom scripting.
+
+**Acceptance Criteria:**
+
+**Given** the user runs `docvet check --all --format sarif`
+**When** findings exist
+**Then** output is valid SARIF v2.1.0 JSON with `$schema`, `version`, `runs[].tool.driver` (name, version, rules[]), and `runs[].results[]`
+
+**Given** SARIF output includes rule definitions
+**When** the `rules[]` array is populated
+**Then** each rule has `id`, `shortDescription`, `helpUri` (linking to the docs site rule page), and `defaultConfiguration.level`
+
+**Given** SARIF output includes results
+**When** each finding is serialized
+**Then** it has `ruleId`, `message.text`, `locations[].physicalLocation` (artifactLocation.uri, region.startLine), and `level`
+
+**Given** no findings exist
+**When** `--format sarif` is used
+**Then** valid SARIF is produced with an empty `results[]` array
+
+**Given** the SARIF file is uploaded via `github/codeql-action/upload-sarif@v3`
+**When** GitHub processes it
+**Then** findings appear as code scanning alerts on the repository's Security tab
+
+**Given** the SARIF output
+**When** generated with `--format sarif`
+**Then** the formatter reuses the existing JSON findings pipeline, adding SARIF envelope structure

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -13,8 +13,10 @@ stepsCompleted:
   - 'step-11-polish'
   - 'step-12-complete'
 status: 'complete'
-lastEdited: '2026-02-19'
+lastEdited: '2026-03-06'
 editHistory:
+  - date: '2026-03-06'
+    changes: 'Added Growth phase (Epics 31-33) informed by party-mode consensus and competitive analysis (March 2026); added 4 journeys (J15 Fixer, J16 Suppressor, J17 Dashboard Glancer, J18 VS Code Developer), 30 FRs (FR128-FR157) covering fix command/inline suppression/summary flag/config show-defaults/dynamic badge/VS Code extension/SARIF output/flagship OSS runs, 10 NFRs (NFR67-NFR76) covering fix constraints/suppression conventions/VS Code architecture/SARIF reuse/badge schema/summary formula; added Fix Module Specification and Suppression Specification sections; updated Reporting Module with SARIF and summary additions; added Phases 7-9 to Project Scoping; updated Growth & Vision with concrete epic scope; updated Document Roadmap counts'
   - date: '2026-02-19'
     changes: 'Added v1.0 "Polish & Publish" section informed by market research (February 2026); added 3 journeys (J12 Explorer, J13 Integrator, J14 Enforcer), 17 FRs (FR111-FR127) covering packaging/pre-commit/GitHub Action/README/docs site/rule reference/dogfooding/API surface, 12 NFRs (NFR55-NFR66) covering packaging quality/documentation quality/CI integration/compatibility/dogfooding/API stability; updated Executive Summary with v1.0 publication scope; added Adoption Success to Success Criteria; updated Competitive Context with pydoclint/pydocstyle data; renamed Reporting to Complete status; added v1.0 Phase 6 to Project Scoping with 8 deliverables mapped to issues #49-#56; updated Growth & Vision with post-launch marketing tactics'
   - date: '2026-02-11'
@@ -62,14 +64,24 @@ inputDocuments:
   - 'gh-issue-55'
   - 'gh-issue-56'
   - '_bmad-output/planning-artifacts/research/market-python-devtool-presentation-research-2026-02-19.md'
+  - '_bmad-output/planning-artifacts/epics-quick-wins-lifecycle-visibility.md'
+  - 'gh-issue-256'
+  - 'gh-issue-305'
+  - 'gh-issue-306'
+  - 'gh-issue-308'
+  - 'gh-issue-309'
+  - 'gh-issue-310'
+  - 'gh-issue-160'
+  - 'gh-issue-163'
+  - 'gh-issue-164'
 documentCounts:
   briefs: 0
   research: 1
   brainstorming: 0
-  projectDocs: 18
+  projectDocs: 29
 workflowType: 'prd'
 projectName: 'docvet'
-featureScope: 'enrichment-freshness-coverage-griffe-reporting-and-v1-publish'
+featureScope: 'enrichment-freshness-coverage-griffe-reporting-v1-publish-and-growth'
 ---
 
 # Product Requirements Document - docvet
@@ -85,9 +97,11 @@ The enrichment check fills a 4-year ecosystem gap by detecting missing docstring
 
 This PRD also defines the **v1.0 "Polish & Publish"** phase — the packaging, presentation, and integration infrastructure required to ship docvet as a credible, installable, and discoverable Python developer tool. This covers PyPI publication, pre-commit hook, GitHub Action, mkdocs-material documentation site, rule reference pages, README with comparison table, dogfooding on docvet's own codebase, and API surface audit.
 
+This PRD further defines the **Growth phase** — the post-v1.0 feature expansion that completes the linter lifecycle and extends docvet's reach into editors and CI platforms. The Growth phase delivers: `docvet fix` for AST-based docstring section scaffolding (no LLM, no libcst), inline suppression comments (`# docvet: ignore[rule-id]`) for intentional deviations, a `--summary` flag for per-check quality percentages, a dynamic shields.io badge via GitHub Gist, `docvet config --show-defaults` for effective configuration introspection, a VS Code extension wrapping the existing LSP server, SARIF v2.1.0 output for GitHub Code Scanning integration, and flagship runs on major OSS projects for social proof.
+
 **Target users:** Python developers writing Google-style docstrings, teams using mkdocs-material + mkdocstrings.
 
-**Scope:** Enrichment: 10 rule identifiers covering 14 detection scenarios, `required` vs `recommended` categorization, full config via `[tool.docvet.enrichment]`. Freshness: 5 rule identifiers across diff mode (3 severity-tiered rules) and drift mode (2 threshold-based rules), full config via `[tool.docvet.freshness]`. Griffe: 3 rule identifiers for rendering compatibility warnings, optional dependency on griffe library, no per-check configuration. Coverage: 1 rule identifier for missing `__init__.py` detection, pure filesystem check with no configuration. Reporting: terminal formatter (ANSI colors, file grouping, summary line), markdown formatter (table format for CI/PR comments), `--output` file support, exit code logic based on `fail-on` / `warn-on` configuration. v1.0 Publish: PyPI package with classifiers and adjacent-tool tags, `.pre-commit-hooks.yaml` with `id: docvet`, first-party GitHub Action, mkdocs-material docs site with rule reference pages following the What/Why/Example/Fix template, README with layer comparison table and single-command quickstart, dogfooding badge.
+**Scope:** Enrichment: 10 rule identifiers covering 14 detection scenarios, `required` vs `recommended` categorization, full config via `[tool.docvet.enrichment]`. Freshness: 5 rule identifiers across diff mode (3 severity-tiered rules) and drift mode (2 threshold-based rules), full config via `[tool.docvet.freshness]`. Griffe: 3 rule identifiers for rendering compatibility warnings, optional dependency on griffe library, no per-check configuration. Coverage: 1 rule identifier for missing `__init__.py` detection, pure filesystem check with no configuration. Reporting: terminal formatter (ANSI colors, file grouping, summary line), markdown formatter (table format for CI/PR comments), SARIF v2.1.0 formatter for GitHub Code Scanning, `--output` file support, exit code logic based on `fail-on` / `warn-on` configuration, `--summary` flag for per-check quality percentages. v1.0 Publish: PyPI package with classifiers and adjacent-tool tags, `.pre-commit-hooks.yaml` with `id: docvet`, first-party GitHub Action, mkdocs-material docs site with rule reference pages following the What/Why/Example/Fix template, README with layer comparison table and single-command quickstart, dogfooding badge. Growth: `docvet fix` AST-based section scaffolding (8 section types, dry-run, all discovery modes), inline suppression comments (line-level and file-level, post-filter architecture), `docvet config --show-defaults`, dynamic shields.io badge via Gist, VS Code extension (thin LSP wrapper with Language Model Tools), SARIF output for `github/codeql-action/upload-sarif@v3`, flagship OSS runs on 3+ major projects.
 
 ### Key Terms
 
@@ -108,10 +122,10 @@ This PRD also defines the **v1.0 "Polish & Publish"** phase — the packaging, p
 This PRD is organized in 6 parts:
 
 1. **Success Criteria & Scope** (Sections 1-3): Vision, competitive context, MVP boundaries, v1.0 publication scope, and growth roadmap
-2. **User Journeys** (Section 4): 14 scenarios demonstrating all 19 rules in action across 10 developer personas, plus 3 adoption journeys (install, integrate, reference)
-3. **Module Specifications** (Sections 5-9): Technical contracts for enrichment, freshness, coverage, griffe, and reporting — each with integration contract, rule taxonomy, config schema, and implementation guidance
-4. **Phased Development** (Section 10): Epic breakdown with 5 complete phases, v1.0 publish phase, and post-launch growth candidates
-5. **Requirements** (Sections 11-12): 127 FRs and 66 NFRs with traceability to journeys and success criteria
+2. **User Journeys** (Section 4): 18 scenarios demonstrating all 19 rules in action across 10 developer personas, plus 3 adoption journeys (install, integrate, reference) and 4 growth journeys (fix, suppress, dashboard, VS Code)
+3. **Module Specifications** (Sections 5-11): Technical contracts for enrichment, freshness, coverage, griffe, reporting, fix, and suppression — each with integration contract, rule taxonomy, config schema, and implementation guidance
+4. **Phased Development** (Section 12): Epic breakdown with 6 complete phases, 3 growth phases, and post-launch candidates
+5. **Requirements** (Sections 13-14): 157 FRs and 76 NFRs with traceability to journeys and success criteria
 6. **Metadata** (YAML frontmatter): Edit history, input documents, classification, and workflow tracking
 
 For implementation: start with Module Specifications (Sections 5-9) and FRs/NFRs (Sections 11-12).
@@ -159,6 +173,21 @@ For stakeholder review: focus on Success Criteria (Section 1) and User Journeys 
 - Running `docvet check --all` on docvet's own codebase produces zero findings — the tool dogfoods itself, proving the "docs vetted | docvet" badge is earned
 - The docs site is live, loads in under 3 seconds, includes search, and covers Getting Started, all 19 rules, configuration, and CLI reference
 
+### Growth Success
+
+- A developer runs `docvet fix --dry-run` and sees a diff of scaffolded sections before any files are modified — previewing exactly what will change
+- A developer runs `docvet fix` and gets missing Raises, Args, Yields, Attributes, and Examples sections scaffolded with parameter names and `[TODO: describe]` placeholders — a skeleton they fill in, not boilerplate they write from scratch
+- Running `docvet fix` twice on the same file produces no additional changes — the fix is idempotent
+- A developer adds `# docvet: ignore[missing-raises]` to a function's `def` line and that finding is suppressed — intentional deviations are respected without global config changes
+- A developer adds `# docvet: ignore-file[missing-examples]` before the first class/function definition and all `missing-examples` findings in the file are suppressed
+- Suppressed findings appear in `--verbose` output for transparency — nothing is silently hidden
+- A developer runs `docvet check --all --summary` and sees per-check quality percentages (enrichment: 94%, freshness: 100%, coverage: 100%, griffe: 87%) and an overall score — instant project health assessment
+- A project maintainer configures a dynamic badge that updates on each CI run, showing pass/fail status and findings count on their README
+- A developer runs `docvet config --show-defaults` and sees the effective merged configuration with annotations showing which values are user-configured vs built-in defaults
+- A VS Code user opens a Python file and sees docvet diagnostics in the Problems panel without leaving the editor — real-time feedback during development
+- A CI engineer adds `--format sarif` to the workflow and findings appear in GitHub's Security tab as code scanning alerts — zero custom scripting
+- Running `docvet check --all` on FastAPI, Pydantic, or typer produces documented, genuine findings that demonstrate docvet's value on real-world codebases
+
 ### Technical Success
 
 - `check_enrichment(source, tree, config, file_path)` returns `list[Finding]` with zero side effects -- pure function, deterministic output
@@ -198,6 +227,15 @@ For stakeholder review: focus on Success Criteria (Section 1) and User Journeys 
 - `--output report.md` writes the formatted report to a file instead of stdout; `--format markdown` selects the markdown formatter
 - `pip install docvet` installs cleanly in a fresh virtual environment with no compilation step
 - `pip install docvet[griffe]` installs the optional griffe dependency
+- `docvet fix` on a function with missing Raises and Args sections produces a file that passes `docvet check` with zero findings for those sections (roundtrip validation)
+- `docvet fix` run twice on the same file produces identical output on both runs (idempotency)
+- `docvet fix --dry-run` produces a unified diff to stdout without modifying any files on disk
+- A function with `# docvet: ignore[missing-raises]` on its `def` line produces zero `missing-raises` findings; the suppression appears in `--verbose` output
+- A file with `# docvet: ignore-file` before the first class/function definition produces zero findings for all rules in that file
+- `docvet check --all --summary` produces per-check percentages using the formula `(symbols_checked - symbols_with_findings) / symbols_checked * 100`
+- `docvet config --show-defaults` with no `[tool.docvet]` in pyproject.toml prints all built-in defaults in valid TOML format
+- `--format sarif` produces valid SARIF v2.1.0 JSON that passes schema validation and is accepted by `github/codeql-action/upload-sarif@v3`
+- The dynamic badge JSON written to Gist follows shields.io schema v1 (`schemaVersion`, `label`, `message`, `color`)
 - Adding `- repo: https://github.com/Alberto-Codes/docvet` to `.pre-commit-config.yaml` with hook `id: docvet` runs `docvet check` on staged Python files
 - The GitHub Action runs `docvet check` with configurable arguments and exits with the correct code
 - Each of the 19 rule identifiers has a dedicated documentation page with What/Why/Example/Fix sections
@@ -234,9 +272,21 @@ The reporting module delivers the output formatting layer that all check modules
 
 The v1.0 phase delivers the packaging, presentation, and integration infrastructure that makes docvet installable, discoverable, and trustworthy. All check modules and reporting are complete (678 tests, 19 rules); this phase wraps them for public consumption. Market research (February 2026) identified 8 deliverables mapped to GitHub issues #49-#56: dogfooding on own codebase (#49), README with comparison table and quickstart (#50), mkdocs-material documentation site (#51), rule reference pages with What/Why/Example/Fix template (#52), pre-commit hook (#53), GitHub Action and CI badge (#54), PyPI publish with classifiers and adjacent-tool tags (#55), and API surface audit (#56). Competitive analysis of ruff, interrogate, pydoclint, ty, and mypy confirmed these as table-stakes for adoption — 73% of developers demand hands-on value within minutes, documentation quality is the #1 trust signal (34.2%), and pre-commit hooks serve as viral distribution channels. See "Project Scoping & Phased Development > v1.0 Polish & Publish Feature Set" for the authoritative implementation checklist.
 
-### Growth & Vision
+### Growth Phase — Epics 31-33
 
-Growth features include inline suppression, JSON/SARIF output, incomplete section detection (enrichment), hunk-level precision and auto-fix suggestions (freshness), verbose mode with code snippets and suggestions (reporting), and cross-check intelligence (enrichment + freshness + griffe + coverage combined findings). Post-launch growth includes a "Python Docstring Quality Layers" blog post to define the category, submissions to curated lists (vintasoftware/python-linters-and-code-analysis, best-of-python-dev, Slant.co), and early adopter outreach to mkdocs-material projects where griffe_compat is uniquely valuable. Vision includes editor/LSP integration, GitHub Actions annotation format for PR inline comments, and additional docstring style support. See "Project Scoping & Phased Development > Post-Epic Features" for the full Phase 2 and Phase 3 roadmap.
+The Growth phase delivers three epics based on party-mode consensus (17/17 unanimous, March 2026). All v1.0 PRD requirements (FR1-FR127, NFR1-NFR66) are fully satisfied; this phase targets adoption, conversion, and platform expansion.
+
+**Epic 31: Project Health Visibility** — Quick wins (days, not weeks). Dynamic shields.io badge via `schneegans/dynamic-badges-action` writing JSON to GitHub Gist (#256). `--summary` flag printing per-check quality percentages derived from existing `get_documented_symbols()` calls (#306). `docvet config --show-defaults` printing effective merged configuration in TOML format (#309). See "Project Scoping & Phased Development > Phase 7" for deliverables.
+
+**Epic 32: Linter Lifecycle — Fix & Suppress** — Completes the detect→fix→suppress cycle. `docvet fix` generates missing docstring sections from pure AST analysis — no LLM, no libcst, stdlib only (#305). Architecture spike validates insertion strategy before full implementation. Inline suppression comments (`# docvet: ignore[rule-id]`, `# docvet: ignore-file[rule-id]`) implemented as a post-filter on the findings list (#308). See "Project Scoping & Phased Development > Phase 8" for deliverables.
+
+**Epic 33: Ecosystem Visibility & Editor Integration** — Platform expansion. VS Code extension as a thin LSP wrapper launching `docvet lsp --stdio` with Language Model Tools for Copilot agent mode (#160). SARIF v2.1.0 output for GitHub Code Scanning via `github/codeql-action/upload-sarif@v3` (#163). Flagship OSS runs on 3+ major projects (FastAPI, Pydantic, typer) with documented findings published as a docs page (#164). See "Project Scoping & Phased Development > Phase 9" for deliverables.
+
+### Post-Growth Vision
+
+Deferred items reassessed after Epic 33 ships: incomplete section detection (#310, requires exploration spike), architecture Mermaid diagrams (#265), Ruff plugin exploration (#307), negation pattern support in exclude (#148), WebMCP integration (#72). Additional growth candidates: hunk-level precision and auto-fix suggestions (freshness), verbose mode with code snippets and suggestions (reporting), cross-check intelligence (combined findings), per-rule severity override in config, Numpy/Sphinx docstring style support.
+
+Post-launch marketing includes a "Python Docstring Quality Layers" blog post to define the category, submissions to curated lists (vintasoftware/python-linters-and-code-analysis, best-of-python-dev, Slant.co), and early adopter outreach to mkdocs-material projects where griffe_compat is uniquely valuable. Conference lightning talks / blog series on docstring quality automation.
 
 ## User Journeys
 
@@ -647,9 +697,116 @@ The rule name `griffe-unknown-param` links to the docs site.
 
 **Resolution:** Carlos bookmarks the rule reference and starts checking it proactively before PRs. He tells the team that the rule pages are better than reading source code to understand findings.
 
+### Journey 15: The Fixer -- "Scaffolding Over Boilerplate"
+
+**Persona:** Maya (from Journey 1), now a regular docvet user. She runs `docvet enrichment --all` on a new module she wrote and gets 12 findings across 8 functions — all missing Raises, Yields, and Attributes sections. Writing each section from scratch would take 20 minutes.
+
+**Opening Scene:** Maya runs `docvet fix --dry-run` on her module. The terminal shows a unified diff — each function gets scaffolded sections with parameter names pulled from the signature and exception names from the body:
+
+```
+--- src/pipeline/transform.py
++++ src/pipeline/transform.py
+@@ -42,6 +42,10 @@
+     def parse_record(self, raw: dict[str, Any]) -> Record:
+         """Parse a raw API response into a Record.
+
++        Raises:
++            KeyError: [TODO: describe]
++            ValueError: [TODO: describe]
++
+         Args:
+```
+
+12 scaffolded sections across 8 functions. She reviews the diff — everything looks right. No existing content was touched.
+
+**Rising Action:** Maya runs `docvet fix` (no `--dry-run`). The files are modified in-place. She opens her editor and fills in the `[TODO: describe]` placeholders with actual descriptions. She runs `docvet fix` again — no changes. Idempotent.
+
+**Climax:** She runs `docvet check` — zero findings. The scaffolded sections plus her descriptions satisfy all enrichment rules. What would have been 20 minutes of boilerplate writing took 3 minutes of placeholder filling.
+
+**Resolution:** Maya adds `docvet fix --dry-run` to her pre-commit review workflow. Before committing, she previews what's missing, applies the fix, fills in descriptions, and commits with complete docstrings.
+
+### Journey 16: The Suppressor -- "Intentional Deviations"
+
+**Persona:** Raj (from Journey 2), whose team now enforces `docvet check` in CI with enrichment in `fail-on`.
+
+**Opening Scene:** Raj writes an internal utility function `_retry_with_backoff()` that raises `RetryExhausted`. The enrichment check fires `missing-raises`. But this is a private helper — callers are all within the same module, and Raj intentionally does not document the exception in the docstring because it's an implementation detail that should not be part of the public contract.
+
+**Rising Action:** Rather than disabling `require-raises` globally (which would affect all functions), Raj adds a targeted suppression:
+
+```python
+def _retry_with_backoff(fn: Callable, max_retries: int = 3) -> Any:  # docvet: ignore[missing-raises]
+    """Retry a callable with exponential backoff."""
+```
+
+He runs `docvet check` — the `missing-raises` finding for `_retry_with_backoff` is gone. All other functions still enforce `missing-raises`.
+
+**Climax:** The tech lead reviews the PR and asks why the suppression is there. Raj runs `docvet check --verbose` — the suppressed finding appears with a note: `(suppressed by inline comment: # docvet: ignore[missing-raises])`. Full transparency.
+
+**Resolution:** A month later, a colleague adds a file of test fixtures that intentionally has incomplete docstrings. Instead of suppressing each function individually, they add `# docvet: ignore-file` before the first function definition. All findings in the file are suppressed. The suppression comment serves as documentation: "these are intentionally incomplete."
+
+### Journey 17: The Dashboard Glancer -- "Project Health at a Glance"
+
+**Persona:** Carlos (from Journey 4), the tech lead who runs quarterly documentation audits.
+
+**Opening Scene:** Carlos wants a quick health check without reading through individual findings. He runs:
+
+```
+docvet check --all --summary
+```
+
+The output shows:
+
+```
+Enrichment:  94% (127/135 symbols clean)
+Freshness:  100% (0 stale symbols)
+Coverage:   100% (all packages have __init__.py)
+Griffe:      87% (4 symbols with rendering warnings)
+
+Overall: 95%
+
+8 findings (3 required, 5 recommended)
+```
+
+**Rising Action:** Carlos configures a dynamic badge in his CI workflow using `schneegans/dynamic-badges-action`. After each CI run, a shields.io-compatible JSON file is written to a GitHub Gist:
+
+```json
+{"schemaVersion": 1, "label": "docvet", "message": "95% · 8 findings", "color": "yellow"}
+```
+
+His README now shows a live badge that updates with every push to main.
+
+**Climax:** Carlos uses `--summary` with `--format json` to feed metrics into a team dashboard:
+
+```json
+{"summary": {"enrichment": 94, "freshness": 100, "coverage": 100, "griffe": 87, "overall": 95, "total_symbols": 135, "total_findings": 8}}
+```
+
+The team tracks documentation quality alongside test coverage and linting metrics.
+
+**Resolution:** When a developer asks "how good are our docs?", Carlos points at the badge. No explanation needed — the percentage tells the story.
+
+### Journey 18: The VS Code Developer -- "Findings Without Leaving the Editor"
+
+**Persona:** Lina (from Journey 10), who uses VS Code with the Python extension and GitHub Copilot.
+
+**Opening Scene:** Lina installs the `docvet-vscode` extension from the VS Code Marketplace. The extension activates and launches `docvet lsp --stdio` as a subprocess. No configuration needed — it detects docvet in her Python environment automatically.
+
+**Rising Action:** Lina opens `src/data/access.py`. Within a second, yellow squiggles appear under `fetch_records()`. The Problems panel shows:
+
+```
+src/data/access.py:42  missing-raises  Function 'fetch_records' raises ConnectionError but has no Raises: section  [enrichment]
+src/data/access.py:42  griffe-missing-type  Parameter 'limit' has no type annotation  [griffe]
+```
+
+She clicks the first diagnostic — the cursor jumps to line 42. She adds the `Raises:` section, saves, and the squiggle disappears in real time.
+
+**Climax:** Lina opens Copilot chat and asks: "What docstring issues does this file have?" Copilot invokes the `docvet.check` Language Model Tool and returns a contextual summary with fix suggestions. Lina applies the suggestions inline.
+
+**Resolution:** The combination of real-time diagnostics (Problems panel), Copilot integration (Language Model Tools), and terminal commands (for CI/batch) means Lina never leaves her editor for documentation quality. The VS Code extension is the final piece — docvet now covers terminal, CI, editor, and AI assistant workflows.
+
 ### Journey Requirements Traceability
 
-All 10 enrichment rule identifiers are demonstrated across Journeys 1-5 and 8. Journeys 1-5 cover 6 rules: `missing-raises` (Journey 1), `missing-attributes` (Journey 2), `missing-typed-attributes` (Journey 4), `missing-yields` (Journey 3), `missing-warns` and `missing-examples` (Journeys 4-5). Journey 8 covers the remaining 4: `missing-receives`, `missing-other-parameters`, `missing-cross-references`, and `prefer-fenced-code-blocks`. All 5 freshness rule identifiers are demonstrated: Journey 6 covers diff mode (`stale-signature` HIGH/required, `stale-body` MEDIUM/recommended, `stale-import` LOW/recommended as edge case paragraph) and Journey 7 covers drift mode (`stale-drift` and `stale-age`, both recommended). All 3 griffe rule identifiers are demonstrated in Journey 10: `griffe-missing-type` (recommended, main scenario), `griffe-unknown-param` (required, edge case), and `griffe-format-warning` (recommended, implied by griffe's formatting checks). The 1 coverage rule identifier (`missing-init`) is demonstrated in Journey 9. All 19 rule identifiers (10 enrichment + 5 freshness + 3 griffe + 1 coverage) have journey coverage. Journey 11 demonstrates the reporting module: terminal formatting with file grouping and color-coded categories, markdown table output for CI artifacts, summary line, exit code logic based on `fail-on`/`warn-on` configuration, and `--output` file support. Reporting is a cross-cutting capability required by all check module journeys for full journey completion. Journeys 12-14 demonstrate v1.0 adoption infrastructure: Journey 12 (Explorer) covers first install, zero-config trial, and badge adoption (FR111-113, FR118-119, FR125-126). Journey 13 (Integrator) covers pre-commit hook and GitHub Action CI setup (FR114-117, FR120). Journey 14 (Enforcer) covers rule reference navigation and the What/Why/Example/Fix documentation template (FR121-124).
+All 10 enrichment rule identifiers are demonstrated across Journeys 1-5 and 8. Journeys 1-5 cover 6 rules: `missing-raises` (Journey 1), `missing-attributes` (Journey 2), `missing-typed-attributes` (Journey 4), `missing-yields` (Journey 3), `missing-warns` and `missing-examples` (Journeys 4-5). Journey 8 covers the remaining 4: `missing-receives`, `missing-other-parameters`, `missing-cross-references`, and `prefer-fenced-code-blocks`. All 5 freshness rule identifiers are demonstrated: Journey 6 covers diff mode (`stale-signature` HIGH/required, `stale-body` MEDIUM/recommended, `stale-import` LOW/recommended as edge case paragraph) and Journey 7 covers drift mode (`stale-drift` and `stale-age`, both recommended). All 3 griffe rule identifiers are demonstrated in Journey 10: `griffe-missing-type` (recommended, main scenario), `griffe-unknown-param` (required, edge case), and `griffe-format-warning` (recommended, implied by griffe's formatting checks). The 1 coverage rule identifier (`missing-init`) is demonstrated in Journey 9. All 19 rule identifiers (10 enrichment + 5 freshness + 3 griffe + 1 coverage) have journey coverage. Journey 11 demonstrates the reporting module: terminal formatting with file grouping and color-coded categories, markdown table output for CI artifacts, summary line, exit code logic based on `fail-on`/`warn-on` configuration, and `--output` file support. Reporting is a cross-cutting capability required by all check module journeys for full journey completion. Journeys 12-14 demonstrate v1.0 adoption infrastructure: Journey 12 (Explorer) covers first install, zero-config trial, and badge adoption (FR111-113, FR118-119, FR125-126). Journey 13 (Integrator) covers pre-commit hook and GitHub Action CI setup (FR114-117, FR120). Journey 14 (Enforcer) covers rule reference navigation and the What/Why/Example/Fix documentation template (FR121-124). Journeys 15-18 demonstrate Growth phase features: Journey 15 (Fixer) covers `docvet fix` scaffolding, dry-run, and idempotency (FR128-FR139). Journey 16 (Suppressor) covers inline suppression comments at line and file level with verbose transparency (FR140-FR147). Journey 17 (Dashboard Glancer) covers `--summary` flag, dynamic badge, and config introspection (FR148-FR151). Journey 18 (VS Code Developer) covers the VS Code extension with LSP and Language Model Tools (FR152-FR153).
 
 ## Enrichment Module Specification
 
@@ -1130,6 +1287,19 @@ def write_report(
 ) -> None:
     """Write formatted report to a file."""
 
+def format_sarif(
+    findings: list[Finding],
+    *,
+    version: str = "0.0.0",
+) -> str:
+    """Format findings as SARIF v2.1.0 JSON for GitHub Code Scanning."""
+
+def format_summary(
+    findings_by_check: dict[str, list[Finding]],
+    symbols_by_check: dict[str, int],
+) -> str:
+    """Format per-check quality percentages and overall score."""
+
 def determine_exit_code(
     findings_by_check: dict[str, list[Finding]],
     config: DocvetConfig,
@@ -1150,7 +1320,9 @@ def determine_exit_code(
 - **`verbose` mode (MVP)**: when enabled and findings exist, terminal output prefixes the findings block with a header showing the number of files checked and which checks ran (e.g., `Checking 12 files [enrichment, freshness, coverage, griffe]`). When enabled and zero findings exist, prints `No findings.` to stdout instead of silent empty output — confirms the tool ran successfully. Growth candidate: per-finding code snippets and fix suggestions.
 - **`verbose` mode with zero findings**: `format_terminal` with `verbose=True` and an empty finding list returns `"No findings.\n"` instead of empty string. This is the only case where zero findings produces output.
 - **Zero findings (non-verbose)**: formatters return an empty string (no output, no summary line). `determine_exit_code` returns `0`.
-- **Pure functions**: `format_terminal` and `format_markdown` have no side effects. `write_report` performs file I/O only. `determine_exit_code` is pure.
+- **`format_sarif` produces SARIF v2.1.0 JSON**: includes `$schema`, `version: "2.1.0"`, `runs[].tool.driver` with tool name/version/rules array, and `runs[].results[]` with `ruleId`, `message.text`, `locations[].physicalLocation`, and `level`. Each rule in `rules[]` includes `id`, `shortDescription`, `helpUri` (linking to docs site rule page), and `defaultConfiguration.level`. Reuses ~60% of existing JSON formatter code. Empty findings produce valid SARIF with empty `results[]` array.
+- **`format_summary` produces per-check percentages**: formula is `(symbols_checked - symbols_with_findings) / symbols_checked * 100`, rounded to nearest integer. Symbol counts derived from `get_documented_symbols()` calls already in the check pipeline — no separate AST pass. Works with `--format json` (summary as JSON object with numeric fields) and terminal (human-readable percentage lines). When all checks show 100%, overall score is 100%.
+- **Pure functions**: `format_terminal`, `format_markdown`, `format_sarif`, and `format_summary` have no side effects. `write_report` performs file I/O only. `determine_exit_code` is pure.
 
 **Import contract:**
 
@@ -1183,6 +1355,41 @@ Each line is self-contained (`file:line: rule message [category]`) and independe
 | src/models/schema.py | 15 | missing-attributes | SchemaResult | Dataclass 'SchemaResult' has 4 fields but no Attributes: section | required |
 
 **3 findings** (2 required, 1 recommended)
+```
+
+**SARIF format:**
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {
+      "driver": {
+        "name": "docvet",
+        "version": "1.11.0",
+        "informationUri": "https://alberto-codes.github.io/docvet/",
+        "rules": [
+          {"id": "missing-raises", "shortDescription": {"text": "..."}, "helpUri": "https://alberto-codes.github.io/docvet/rules/missing-raises/", "defaultConfiguration": {"level": "warning"}}
+        ]
+      }
+    },
+    "results": [
+      {"ruleId": "missing-raises", "message": {"text": "..."}, "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/core/engine.py"}, "region": {"startLine": 23}}}], "level": "warning"}
+    ]
+  }]
+}
+```
+
+**Summary format (terminal):**
+
+```
+Enrichment:  94% (127/135 symbols clean)
+Freshness:  100% (0 stale symbols)
+Coverage:   100% (all packages have __init__.py)
+Griffe:      87% (4 symbols with rendering warnings)
+
+Overall: 95%
 ```
 
 ### Exit Code Logic
@@ -1225,6 +1432,170 @@ The exit code depends on which *check names* are in `fail-on`, not on individual
 - No new runtime dependencies: `typer` (already a dependency) for ANSI styling, stdlib `pathlib` for file I/O
 - Imports `Finding` from `checks/__init__.py` and `DocvetConfig` from `config.py`
 - No cross-imports with any check module
+
+## Fix Module Specification
+
+### Project-Type Overview
+
+The fix module generates missing docstring sections from pure AST analysis — no LLM, no libcst, no external dependencies. It operates as a pure function that takes source code and an AST, identifies symbols with missing sections (using the same detection logic as enrichment), and returns modified source code with scaffolded sections inserted at the correct positions. The CLI layer handles file I/O (reading source, writing modified files, dry-run diff output).
+
+The fix command completes the linter lifecycle: `docvet check` detects issues, `docvet fix` scaffolds solutions, inline suppression handles intentional deviations. This mirrors the ruff pattern (`ruff check` → `ruff check --fix`) that developers already expect from modern Python linters.
+
+### Integration Contract
+
+**Public API:**
+
+```python
+def fix_file(
+    source: str,
+    tree: ast.Module,
+    config: EnrichmentConfig,
+    file_path: str,
+) -> str:
+    """Return source with missing docstring sections scaffolded.
+
+    Returns the original source unchanged if no fixes are needed.
+    """
+```
+
+- **Pure function**: takes source string, returns modified source string. No file I/O.
+- **Same inputs as `check_enrichment`**: reuses the enrichment detection logic to identify what's missing, then generates section text instead of findings
+- **Deterministic**: same input always produces same output
+- **Idempotent**: running on already-fixed output returns the input unchanged
+- **Preserves existing content**: existing docstring text is never modified — only new sections are inserted
+- **Returns original source when nothing to fix**: no unnecessary writes
+- **AST line numbers for positioning**: uses `ast.get_docstring()` line information and string operations to insert sections at the correct indentation level after the last existing section (or after the summary line if no sections exist)
+- **No libcst dependency**: stdlib `ast` provides sufficient line number information for insertion. The function operates on the source string directly using line splitting, not CST node manipulation
+
+**Scaffolded section format:**
+
+```python
+# For a function that raises ValueError and KeyError:
+"""Existing summary line.
+
+Raises:
+    ValueError: [TODO: describe]
+    KeyError: [TODO: describe]
+"""
+
+# For a dataclass with fields name and age:
+"""Existing summary line.
+
+Attributes:
+    name (str): [TODO: describe]
+    age (int): [TODO: describe]
+"""
+
+# For a generator:
+"""Existing summary line.
+
+Yields:
+    [TODO: describe]
+"""
+```
+
+**Sections supported:** Args, Returns, Raises, Yields, Receives, Warns, Attributes, Examples (8 section types). `Other Parameters` and `See Also` are not auto-scaffolded (too context-dependent).
+
+### Technical Guidance for Implementation
+
+1. **Detect missing sections**: call the same detection logic used by `check_enrichment` to identify which sections each symbol is missing
+2. **Compute insertion point**: for each symbol, find the end of the existing docstring content. If sections already exist, insert after the last section. If only a summary line exists, insert after a blank line following the summary
+3. **Determine indentation**: match the indentation of the existing docstring (typically 4 spaces + 4 spaces for class methods, 4 spaces for module-level functions)
+4. **Build section text**: for each missing section, generate the header and entries. Raises/Warns: extract exception/warning names from AST. Args: extract parameter names from function signature. Attributes: extract field names from class definition. Yields/Receives/Returns/Examples: use `[TODO: describe]` placeholder
+5. **Apply insertions bottom-up**: process symbols from bottom of file to top (reverse line order) so that line number offsets from earlier insertions don't invalidate later insertion points
+6. **Validate roundtrip**: after all insertions, the modified source should parse as valid Python (`ast.parse()` succeeds)
+
+**Edge cases:**
+
+- **No docstring at all**: skip — presence checking is interrogate's job, and `fix` cannot determine appropriate summary text
+- **One-line docstring**: expand to multi-line format before inserting sections
+- **Existing sections present**: insert new sections after the last existing section, maintaining section ordering convention (Args, Returns, Raises, Yields, Receives, Warns, Attributes, Examples)
+- **Nested classes/functions**: each symbol's indentation is computed independently from its AST node
+- **`__init__.py` modules**: scaffold module-level Attributes and Examples sections
+
+**Dependencies:**
+
+- No new runtime dependencies: stdlib `ast`, `textwrap`, existing `ast_utils`
+- Reuses enrichment detection logic from `checks/enrichment.py`
+- No cross-imports with freshness, coverage, or griffe modules
+
+## Suppression Specification
+
+### Project-Type Overview
+
+Inline suppression allows developers to mark intentional deviations from docvet rules without disabling rules globally. The implementation is a **post-filter** on the findings list — no check module (`_check_*` function) is modified. The suppression filter runs after all checks complete and before reporting, removing findings that match suppression comments in the source code.
+
+This follows the established convention used by ruff (`# noqa`), mypy (`# type: ignore`), and pylint (`# pylint: disable`). The syntax `# docvet: ignore[rule-id]` is intentionally verbose to avoid ambiguity with other tools' suppression comments.
+
+### Suppression Syntax
+
+```python
+# Line-level suppression (on the def/class line):
+def my_function():  # docvet: ignore[missing-raises]
+    """Summary."""
+
+def my_function():  # docvet: ignore[missing-raises,missing-yields]
+    """Summary."""
+
+def my_function():  # docvet: ignore
+    """Summary."""
+
+# File-level suppression (before the first class/function definition):
+# docvet: ignore-file[missing-examples]
+
+# docvet: ignore-file
+```
+
+### Integration Contract
+
+**Public API:**
+
+```python
+def filter_suppressed(
+    findings: list[Finding],
+    sources: dict[str, str],
+) -> tuple[list[Finding], list[Finding]]:
+    """Partition findings into active and suppressed.
+
+    Args:
+        findings: All findings from all checks.
+        sources: Map of file path to source code string.
+
+    Returns:
+        Tuple of (active_findings, suppressed_findings).
+        Active findings are reported normally.
+        Suppressed findings are reported only in verbose mode.
+    """
+```
+
+- **Post-filter architecture**: operates on the final `list[Finding]` after all checks complete. No check module is aware of suppression.
+- **Pure function**: takes findings and source code, returns partitioned lists. No I/O.
+- **Source-based parsing**: reads suppression comments from the source strings that are already loaded by the CLI for AST parsing. No additional file reads.
+- **Line-level matching**: for a finding at `(file, line, symbol, rule)`, checks if the symbol's `def`/`class` line has a matching `# docvet: ignore[rule]` comment
+- **File-level matching**: for a finding at `(file, *, *, rule)`, checks if the file has a `# docvet: ignore-file[rule]` comment before the first class/function definition
+- **Wildcard support**: `# docvet: ignore` (no brackets) suppresses all rules for that symbol. `# docvet: ignore-file` suppresses all rules for the entire file.
+- **Invalid rule warning**: if a suppression comment references a rule ID that doesn't match any known rule, emit a warning to stderr (e.g., `Warning: unknown rule 'nonexistent-rule' in suppression comment at file.py:5`)
+
+### Technical Guidance for Implementation
+
+1. **Parse suppression comments**: use Python's `tokenize` module or regex on source lines to extract `# docvet: ignore[...]` and `# docvet: ignore-file[...]` comments
+2. **Build suppression index**: for each file, build two structures: (a) a map of `def`/`class` line numbers to their suppressed rule sets, and (b) a set of file-level suppressed rules
+3. **Filter findings**: for each finding, check file-level suppressions first (O(1) set lookup), then line-level suppressions (map the finding's symbol back to its definition line via AST)
+4. **Partition output**: return both active and suppressed findings so the CLI can display suppressed findings in verbose mode
+5. **File-level scope**: "before the first class/function definition" means any line before the first `ast.FunctionDef`, `ast.AsyncFunctionDef`, or `ast.ClassDef` node's `lineno`. This allows suppression comments after the module docstring and imports, following the pylint convention.
+
+**Edge cases:**
+
+- **Multiple suppression comments on the same line**: only one `# docvet:` comment per line is supported. If multiple appear, only the first is parsed.
+- **Suppression on a decorated function**: the comment must be on the `def` line, not on a decorator line
+- **Suppression for module-level findings**: module-level findings (e.g., `missing-init`) use file-level suppression, not line-level
+- **Comments inside strings**: the tokenize module correctly distinguishes comments from string content
+
+**Dependencies:**
+
+- No new runtime dependencies: stdlib `tokenize`, `ast`, `re`
+- No cross-imports with any check module
+- Integrates with the CLI between check execution and reporting
 
 ## Project Scoping & Phased Development
 
@@ -1419,14 +1790,108 @@ One internal refactor required before reporting implementation:
 - No internal symbols exported unintentionally
 - Document public API in docs site
 
+### Phase 7: Growth — Project Health Visibility (Epic 31)
+
+**Status:** Not started. Quick wins — days, not weeks.
+
+**Core User Journeys Enabled:** Journey 17 (Dashboard Glancer).
+
+**Deliverables:**
+
+**Dynamic Badge Endpoint (Story 31.1, #256):**
+- GitHub Action step using `schneegans/dynamic-badges-action` writes shields.io-compatible JSON to a GitHub Gist after each CI run
+- JSON follows shields.io schema v1: `{"schemaVersion": 1, "label": "docvet", "message": "passing", "color": "brightgreen"}`
+- Color logic: `brightgreen` (zero findings), `yellow` (warnings only), `red` (failures)
+- README badge via `shields.io/endpoint?url=<gist-raw-url>`
+
+**Summary Flag (Story 31.2, #306):**
+- `--summary` flag on `check` and each subcommand prints per-check quality percentages and overall score
+- Percentage formula: `(symbols_checked - symbols_with_findings) / symbols_checked * 100`
+- Symbol count derived from existing `get_documented_symbols()` calls — no separate AST pass
+- Works with `--format json` (summary as JSON object with numeric fields)
+- Zero findings → all percentages show 100%
+
+**Config Show-Defaults (Story 31.3, #309):**
+- `docvet config --show-defaults` prints effective merged configuration in TOML format
+- Comments annotate which values are user-configured vs built-in defaults
+- Works with `--format json` for machine consumption
+- When no pyproject.toml exists, prints all defaults with a note
+
+### Phase 8: Growth — Linter Lifecycle (Epic 32)
+
+**Status:** Not started. Requires architecture spike before full implementation.
+
+**Core User Journeys Enabled:** Journey 15 (Fixer), Journey 16 (Suppressor).
+
+**Deliverables:**
+
+**Fix Feasibility Spike (Story 32.1, #305):**
+- Proof-of-concept validates AST-based docstring insertion on representative cases
+- Decision document records: chosen insertion strategy, edge cases identified, go/no-go recommendation
+- Tests insertion on one-line docstrings, multi-section docstrings, and idempotency
+
+**Fix Core — Section Scaffolding Engine (Story 32.2, #305):**
+- `fix_file(source, tree, config, file_path) -> str` pure function in `checks/fix.py`
+- Scaffolds 8 section types: Args, Returns, Raises, Yields, Receives, Warns, Attributes, Examples
+- Parameter names from signature, exception names from body, `[TODO: describe]` placeholders
+- Deterministic, idempotent, preserves existing content byte-for-byte
+- No new runtime dependencies — AST-only, no libcst
+
+**Fix CLI Wiring (Story 32.3, #305):**
+- `docvet fix` subcommand with `--dry-run` (unified diff to stdout, no file modification)
+- Supports all discovery modes: diff (default), `--staged`, `--all`, positional args
+- Roundtrip validation: fixed files produce zero enrichment findings for scaffolded sections
+
+**Inline Suppression Comments (Story 32.4, #308):**
+- Line-level: `# docvet: ignore[rule-id]` on def/class line, comma-separated for multiple rules
+- File-level: `# docvet: ignore-file[rule-id]` before first class/function definition
+- Wildcard: `# docvet: ignore` and `# docvet: ignore-file` suppress all rules
+- Post-filter architecture — no `_check_*` functions modified
+- Suppressed findings shown in `--verbose` output with suppression reason
+- Invalid rule IDs in suppression comments produce a warning
+
+### Phase 9: Growth — Ecosystem Visibility & Editor Integration (Epic 33)
+
+**Status:** Not started. Platform expansion.
+
+**Core User Journeys Enabled:** Journey 18 (VS Code Developer).
+
+**Deliverables:**
+
+**VS Code Extension (Story 33.1, #160):**
+- Thin LSP wrapper launching `docvet lsp --stdio` — minimal TypeScript, no bundled Python
+- Diagnostics in Problems panel with rule ID, message, file, and line number
+- Language Model Tools for Copilot agent mode (`docvet.check` as a tool)
+- Published to VS Code Marketplace with proper metadata
+- Separate `docvet-vscode` repo with package.json, extension.ts, and CI for Marketplace publishing
+- Helpful error when docvet is not installed
+
+**Flagship OSS Runs & Example Guide (Story 33.2, #164, #158):**
+- Run `docvet check --all` against FastAPI, Pydantic, typer (or 3+ comparable projects)
+- Document findings: counts by rule, notable examples, false positive assessment
+- Open small PRs (5-10 fixes each) on target projects crediting docvet
+- Publish docs page: "What we found running docvet on the Python ecosystem"
+- Include configuration snippets for docvet + mkdocstrings pipeline replication
+
+**SARIF Output Format (Story 33.3, #163):**
+- `--format sarif` produces SARIF v2.1.0 compliant JSON
+- Tool driver with name, version, rules array (id, shortDescription, helpUri, defaultConfiguration.level)
+- Results with ruleId, message.text, locations[].physicalLocation, level
+- Compatible with `github/codeql-action/upload-sarif@v3`
+- Reuses ~60% of existing JSON formatter code
+- Empty findings produce valid SARIF with empty results array
+
 ### Post-Epic Features
 
-**Growth (sequencing TBD based on early adopter feedback):**
+**Deferred (reassess after Epic 33 ships based on user demand):**
 
-Enrichment growth:
-- Inline suppression: `# docvet: ignore[missing-raises]`
-- Incomplete section detection (e.g., `Raises:` section exists but doesn't cover all raised exceptions)
-- `--fix` suggestions (auto-insert empty section skeletons)
+- Incomplete section detection (#310): `Raises:` exists but doesn't list all exceptions. Requires exploration spike.
+- Architecture Mermaid diagrams (#265): contributor DX only, lowest priority
+- Ruff plugin exploration (#307): evaluate if docvet enrichment rules can ship as a Ruff plugin
+- Negation pattern support in exclude (#148)
+- WebMCP integration (#72): Chrome 146+ Canary feature flag
+
+**Additional growth candidates:**
 
 Freshness growth:
 - Hunk-level precision (show exactly which hunk changed, not just the symbol)
@@ -1436,7 +1901,7 @@ Freshness growth:
 Coverage growth:
 - Namespace package support (PEP 420): config toggle to exclude specific directories from `missing-init` checking
 - `__init__.py` content analysis: detect empty `__init__.py` that should re-export package symbols
-- Auto-fix: create missing `__init__.py` files via `--fix` flag
+- Auto-fix: create missing `__init__.py` files via `docvet fix` flag
 
 Griffe growth:
 - Per-rule disable toggles (e.g., `disable-griffe-missing-type = true`) via `[tool.docvet.griffe]`
@@ -1445,28 +1910,13 @@ Griffe growth:
 
 Reporting growth:
 - Verbose mode: code snippets and fix suggestions per finding
-- JSON output format for CI integration pipelines
-- SARIF output format for GitHub Code Scanning integration
 - GitHub Actions annotation format (`::warning file=...`) for PR inline comments
 - Configurable grouping (by file, by rule, by check, by category)
-- `--fix` dry-run mode showing proposed changes alongside findings
 
 Shared growth:
 - Rule documentation URLs in findings (ruff pattern)
 - Per-rule severity override in config
 - Cross-check intelligence (enrichment + freshness + griffe + coverage combined findings)
-
-**Post-Launch Marketing:**
-
-- "Python Docstring Quality Layers" blog post — define the category, introduce the six-layer model, position docvet as the tool for layers 3-6
-- Curated list submissions: vintasoftware/python-linters-and-code-analysis, best-of-python-dev, Slant.co comparison pages
-- Early adopter outreach to mkdocs-material projects where griffe_compat check is uniquely valuable
-- Conference lightning talks / blog series on docstring quality automation
-
-**Vision:**
-
-- Editor/LSP integration for real-time feedback
-- GitHub Actions annotation format for PR inline comments
 
 ### Risk Mitigation Strategy
 
@@ -1501,6 +1951,30 @@ Shared growth:
 - Terminal color rendering differences across platforms -- mitigated by using `typer.style()` (wraps click's ANSI handling) and respecting `NO_COLOR`; non-TTY detection suppresses colors
 - Exit code logic correctness -- mitigated by simple boolean check (any fail-on check with findings → exit 1); comprehensive unit tests with all combinations of fail-on/warn-on/empty findings
 - CLI refactor scope (replacing 4 inline `typer.echo()` patterns) -- mitigated by the reporting module being a pure consumer of `list[Finding]`; existing tests verify check output, reporting tests verify formatting independently
+
+**Fix Module Technical Risks:**
+
+- AST line number accuracy for insertion points -- mitigated by architecture spike (Story 32.1) validating the approach on representative cases before committing to full implementation
+- One-line to multi-line docstring expansion -- mitigated by testing all docstring formats (one-line, multi-line no sections, multi-line with sections) in the spike
+- Indentation correctness across nested scopes -- mitigated by computing indentation from the AST node's `col_offset` rather than heuristics
+- Bottom-up insertion ordering -- mitigated by processing symbols in reverse line order so earlier insertions don't invalidate later line numbers
+
+**Suppression Technical Risks:**
+
+- Comment parsing accuracy (distinguishing `# docvet:` from string content) -- mitigated by using Python's `tokenize` module which correctly separates comments from strings
+- Performance impact of post-filter -- mitigated by the filter being O(n) over findings with O(1) set lookups per finding; negligible relative to check execution time
+- File-level scope boundary ("before first class/function definition") -- mitigated by using AST node `lineno` for the first `FunctionDef`/`AsyncFunctionDef`/`ClassDef`, following the pylint convention
+
+**VS Code Extension Technical Risks:**
+
+- LSP server stability -- mitigated by the existing `docvet lsp` implementation being already functional; the extension is a thin wrapper, not a new server
+- Language Model Tools API stability -- mitigated by the API being part of VS Code's stable extension API; Copilot tool integration is a bonus feature, not a core requirement
+- Cross-platform extension packaging -- mitigated by VS Code extensions being platform-independent JavaScript bundles
+
+**SARIF Technical Risks:**
+
+- SARIF schema compliance -- mitigated by validating output against the official SARIF v2.1.0 JSON schema in tests
+- CodeQL upload compatibility -- mitigated by testing with `github/codeql-action/upload-sarif@v3` in CI
 
 **Market Risks:** Minimal -- no existing tool maps git diffs to AST symbols for stale docstring detection. No existing linter catches griffe parser warnings before `mkdocs build`. Novel capabilities in the Python ecosystem. Coverage check fills a gap where developers currently discover missing `__init__.py` only after mkdocs builds silently omit modules.
 
@@ -1734,6 +2208,60 @@ Shared growth:
 
 - **FR127:** All public modules define `__all__` exports, ensuring only intentional symbols are part of the stable v1 public API
 
+### Fix Command
+
+- **FR128:** The system can generate missing docstring sections from pure AST analysis, scaffolding Args, Returns, Raises, Yields, Receives, Warns, Attributes, and Examples sections with parameter names from the function signature, exception names from the body, and `[TODO: describe]` placeholders
+- **FR129:** The fix command is deterministic — same source input always produces the same modified output
+- **FR130:** The fix command is idempotent — running fix on already-fixed output produces no additional changes
+- **FR131:** The fix command preserves existing docstring content byte-for-byte — only new sections are inserted, existing text is never modified
+- **FR132:** A developer can preview fix changes via `docvet fix --dry-run`, which prints a unified diff to stdout without modifying any files
+- **FR133:** The fix command supports all file discovery modes: git diff (default), `--staged`, `--all`, and positional file arguments
+- **FR134:** The fix command scaffolds sections for all symbol types: functions, methods, classes (plain, dataclass, NamedTuple, TypedDict), generators, and `__init__.py` modules
+- **FR135:** The fix command skips symbols that have no docstring at all — fix scaffolds sections, not entire docstrings
+- **FR136:** The fix command inserts new sections after the last existing section in a docstring, maintaining the conventional section ordering (Args, Returns, Raises, Yields, Receives, Warns, Attributes, Examples)
+- **FR137:** After fix modifies files, running `docvet check` on those files produces zero enrichment findings for the scaffolded sections (roundtrip validation)
+- **FR138:** The fix command expands one-line docstrings to multi-line format when sections need to be inserted
+- **FR139:** A developer can run the fix command via `docvet fix` as a standalone subcommand
+
+### Inline Suppression
+
+- **FR140:** A developer can suppress a specific finding by adding `# docvet: ignore[rule-id]` on the `def` or `class` line of the symbol
+- **FR141:** A developer can suppress multiple rules on a single symbol by using comma-separated rule IDs: `# docvet: ignore[rule-a,rule-b]`
+- **FR142:** A developer can suppress all rules for a single symbol by using `# docvet: ignore` (no brackets) on the `def` or `class` line
+- **FR143:** A developer can suppress a specific rule for an entire file by adding `# docvet: ignore-file[rule-id]` before the first class or function definition
+- **FR144:** A developer can suppress all rules for an entire file by adding `# docvet: ignore-file` before the first class or function definition
+- **FR145:** The system can report suppressed findings in `--verbose` output, showing the suppressed finding with a note indicating the suppression reason and location
+- **FR146:** The suppression filter operates as a post-filter on the findings list — no check module (`_check_*` function) is aware of or modified for suppression
+- **FR147:** The system can emit a warning when a suppression comment references an unrecognized rule ID (e.g., `# docvet: ignore[nonexistent-rule]`)
+
+### Summary Flag
+
+- **FR148:** A developer can use `--summary` with `docvet check` or any subcommand to see per-check quality percentages (e.g., enrichment: 94%, freshness: 100%) and an overall score alongside normal findings output
+- **FR149:** The `--summary` flag works with `--format json`, producing a `summary` object with numeric fields for each check's percentage, total symbols checked, total findings, and overall score
+
+### Config Introspection
+
+- **FR150:** A developer can run `docvet config --show-defaults` to print the effective merged configuration in TOML format, with comments annotating which values are user-configured vs built-in defaults, and JSON format via `--format json`
+
+### Dynamic Badge
+
+- **FR151:** The system can write a shields.io-compatible JSON file to a GitHub Gist after each CI run, using `schneegans/dynamic-badges-action`, with pass/fail status and findings count as the badge message
+
+### VS Code Extension
+
+- **FR152:** A VS Code extension can launch `docvet lsp --stdio` as a subprocess and publish diagnostics to the Problems panel with rule ID, message, file, and line number, updating in real-time as the user edits and saves
+- **FR153:** The VS Code extension can contribute Language Model Tools for Copilot agent mode, allowing Copilot to invoke `docvet.check` as a tool and return findings contextually
+
+### SARIF Output
+
+- **FR154:** A developer can use `--format sarif` to produce SARIF v2.1.0 compliant JSON output with `$schema`, `version`, `runs[].tool.driver` (name, version, rules array with id, shortDescription, helpUri, defaultConfiguration.level), and `runs[].results[]` (ruleId, message.text, locations[].physicalLocation, level)
+- **FR155:** The SARIF output is compatible with `github/codeql-action/upload-sarif@v3`, causing docvet findings to appear as code scanning alerts on the repository's Security tab
+
+### Flagship OSS Runs
+
+- **FR156:** Running `docvet check --all` against 3+ major Google-style Python projects (e.g., FastAPI, Pydantic, typer) produces documented findings with counts by rule, notable examples, and false positive assessment
+- **FR157:** Flagship findings are published as a docs page or blog post titled "What we found running docvet on the Python ecosystem," including configuration snippets for replication
+
 ## Non-Functional Requirements
 
 ### Performance
@@ -1891,3 +2419,34 @@ Shared growth:
 - **NFR64:** The public API surface (`Finding` dataclass, check functions, CLI command names, CLI option names) is stable for v1 — no breaking changes within the v1.x lifecycle. Additions (new fields, new options) are allowed; removals and renames are not
 - **NFR65:** All public modules define `__all__` exports — importing `from docvet.checks import *` or `from docvet import *` produces only the intended public symbols
 - **NFR66:** The v1 API stability commitment covers: `Finding` (6 fields), `check_enrichment`, `check_freshness_diff`, `check_freshness_drift`, `check_coverage`, `check_griffe_compat`, and all CLI subcommand names (`check`, `enrichment`, `freshness`, `coverage`, `griffe`)
+
+### Fix Command Constraints
+
+- **NFR67:** The fix command adds zero runtime dependencies — AST-only implementation using stdlib `ast`, `textwrap`, and string operations. No libcst, no tree-sitter, no LLM
+- **NFR68:** The fix command uses AST line numbers for insertion positioning — no CST dependency. Insertion operates on the source string via line splitting and joining
+
+### Suppression Conventions
+
+- **NFR69:** Suppression comment parsing uses the `tokenize` module or AST comment extraction to correctly distinguish comments from string content
+- **NFR70:** Suppression syntax follows established Python tooling conventions (`# tool: directive[args]`), consistent with ruff (`# noqa`), mypy (`# type: ignore`), and pylint (`# pylint: disable`)
+
+### VS Code Extension Architecture
+
+- **NFR71:** The VS Code extension is a thin LSP wrapper — minimal TypeScript, no bundled Python runtime, no duplicate analysis logic. The extension's sole responsibility is launching `docvet lsp --stdio` and forwarding diagnostics
+
+### SARIF Reuse
+
+- **NFR72:** The SARIF formatter reuses approximately 60% of the existing JSON formatter code, adding SARIF envelope structure (`$schema`, `version`, `runs`, `tool.driver`) around the existing finding serialization
+
+### Growth General
+
+- **NFR73:** All new features maintain the zero-dependency core — typer remains the only required runtime dependency. No new required packages.
+- **NFR74:** All new subcommands (`fix`, `config`) follow existing CLI patterns, including the `_output_and_exit` unified output pipeline where applicable
+
+### Badge Schema
+
+- **NFR75:** The dynamic badge JSON endpoint uses shields.io schema v1 with fields `schemaVersion` (integer, value 1), `label` (string), `message` (string), and `color` (string)
+
+### Summary Formula
+
+- **NFR76:** Summary percentage calculation uses the formula `(symbols_checked - symbols_with_findings) / symbols_checked * 100`, rounded to the nearest integer. Division by zero (zero symbols checked) produces 100% (no findings possible)


### PR DESCRIPTION
Adds all planning artifacts for the post-v1.0 Growth phase (Epics 31-33),
covering project health visibility, linter lifecycle (fix + suppress), and
ecosystem visibility. These artifacts were developed collaboratively with
3 party-mode architectural reviews that surfaced and resolved 21 findings.

- Extend PRD with 30 FRs, 10 NFRs, 4 user journeys, Fix/Suppression module
  specs, phases 7-9, and growth-phase risks
- Extend architecture with 7 decisions, implementation patterns, project
  structure (3 new modules), and validation with full FR/NFR coverage
- Add epics document with 25 FRs, 10 NFRs, 3 epics, and 10 stories

Test: docs-only — no code changes

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Planning artifact content: decision consistency across PRD, architecture, and epics documents.

### Related
Builds on completed Epics 1-13 (v1.0). Targets GitHub issues #256, #305, #306, #308, #309, #160, #163, #164.