### PR TITLE
fix(checks): replace <module> sentinel with display names in findings

### DIFF
--- a/src/docvet/ast_utils.py
+++ b/src/docvet/ast_utils.py
@@ -1,9 +1,9 @@
 """Shared AST helpers for docstring range extraction and symbol mapping.
 
-Provides the ``Symbol`` dataclass and utilities for walking an AST tree
-to extract documented symbols, their line ranges, and docstring content.
-Used by the enrichment and freshness check modules to map source
-locations to semantic symbols.
+Provides the ``Symbol`` dataclass, utilities for walking an AST tree
+to extract documented symbols, and :func:`module_display_name` for
+converting file paths to dotted Python module names.  Used by all
+check modules to map source locations to semantic symbols.
 
 Examples:
     Extract documented symbols from a source file:
@@ -315,6 +315,62 @@ def get_documented_symbols(tree: ast.Module) -> list[Symbol]:
     _walk_node(tree, symbols, parent_class=None)
     symbols.sort(key=lambda s: s.line)
     return symbols
+
+
+def module_display_name(file_path: str) -> str:
+    """Convert a file path to a dotted Python module display name.
+
+    Strips source root prefixes (``src/`` or ``lib/``), removes the
+    ``.py`` extension, replaces path separators with dots, and collapses
+    trailing ``.__init__`` into the parent package name.  Handles both
+    absolute and relative paths.
+
+    Args:
+        file_path: Absolute or relative path to a Python source file.
+
+    Returns:
+        Dotted module name suitable for display in findings and messages.
+        Returns ``"<module>"`` for empty input.
+
+    Examples:
+        ```python
+        module_display_name("src/pkg/mod.py")  # -> "pkg.mod"
+        module_display_name("/home/user/src/pkg/mod.py")  # -> "pkg.mod"
+        module_display_name("src/pkg/__init__.py")  # -> "pkg"
+        ```
+    """
+    if not file_path:
+        return "<module>"
+
+    name = file_path.replace("\\", "/")
+
+    # Strip source root: absolute paths use rfind, relative use startswith.
+    for marker in ("/src/", "/lib/"):
+        idx = name.rfind(marker)
+        if idx != -1:
+            name = name[idx + len(marker) :]
+            break
+    else:
+        for prefix in ("src/", "lib/"):
+            if name.startswith(prefix):
+                name = name[len(prefix) :]
+                break
+
+    # Strip leading slashes left over from absolute paths without markers.
+    name = name.lstrip("/")
+
+    # Drop .py extension.
+    if name.endswith(".py"):
+        name = name[: -len(".py")]
+
+    # Convert path separators to dots.
+    name = name.replace("/", ".")
+
+    # Collapse trailing .__init__ to package name.
+    if name.endswith(".__init__"):
+        name = name[: -len(".__init__")]
+
+    return name
 
 
 # ---------------------------------------------------------------------------

--- a/src/docvet/checks/coverage.py
+++ b/src/docvet/checks/coverage.py
@@ -68,7 +68,8 @@ def check_coverage(src_root: Path, files: Sequence[Path]) -> list[Finding]:
 
     Walks from each file's parent directory up to *src_root*, checking
     for ``__init__.py`` existence at each level.  Produces one finding per
-    missing directory, deduplicated, with deterministic ordering.
+    missing directory with a dotted package name as the symbol, deduplicated,
+    with deterministic ordering.
 
     Args:
         src_root: Root directory of the source tree (e.g., ``src/``).
@@ -104,7 +105,7 @@ def check_coverage(src_root: Path, files: Sequence[Path]) -> list[Finding]:
             Finding(
                 file=representative,
                 line=1,
-                symbol="<module>",
+                symbol=dir_rel.replace("/", "."),
                 rule="missing-init",
                 message=message,
                 category="required",

--- a/src/docvet/checks/enrichment.py
+++ b/src/docvet/checks/enrichment.py
@@ -4,7 +4,9 @@ Detects missing docstring sections (Raises, Yields, Attributes, etc.),
 validates cross-reference syntax in See Also sections, and checks for
 non-fenced code block patterns (reporting both doctest and rST findings
 per symbol) by combining AST analysis with section header parsing.
-Implements Layer 3 of the docstring quality model.
+Module-kind findings use :func:`~docvet.ast_utils.module_display_name`
+for human-readable symbol names.  Implements Layer 3 of the docstring
+quality model.
 
 Examples:
     Run the enrichment check on a source file:
@@ -29,7 +31,7 @@ import re
 from collections.abc import Callable
 from typing import Literal
 
-from docvet.ast_utils import Symbol, get_documented_symbols
+from docvet.ast_utils import Symbol, get_documented_symbols, module_display_name
 from docvet.checks._finding import Finding
 from docvet.config import EnrichmentConfig
 
@@ -847,7 +849,7 @@ def _check_missing_attributes(
     2. NamedTuple (base class inspection)
     3. TypedDict (base class inspection)
     4. Plain class with ``__init__`` self-assignments
-    5. ``__init__.py`` module
+    5. ``__init__.py`` module (uses module display name)
 
     Args:
         symbol: The documented symbol to inspect.
@@ -923,12 +925,13 @@ def _check_missing_attributes(
 
     # Branch 5: __init__.py module
     if _is_init_module(file_path):
+        display = module_display_name(file_path)
         return Finding(
             file=file_path,
             line=symbol.line,
-            symbol=symbol.name,
+            symbol=display,
             rule="missing-attributes",
-            message=f"Module '{symbol.name}' has no Attributes: section",
+            message=f"Module '{display}' has no Attributes: section",
             category="required",
         )
 
@@ -1037,8 +1040,8 @@ def _check_missing_examples(
     Classes are gated by list membership — the classified type name
     (``"class"``, ``"dataclass"``, ``"protocol"``, ``"enum"``) must appear
     in ``config.require_examples`` for a finding to be emitted.  Modules
-    trigger whenever ``require_examples`` is non-empty (any non-empty list
-    enables module-level checking).
+    trigger whenever ``require_examples`` is non-empty and use the
+    module display name in findings.
 
     Args:
         symbol: The documented symbol to inspect.
@@ -1060,12 +1063,13 @@ def _check_missing_examples(
     # Module branch: modules trigger when require_examples is non-empty
     # (any type in the list enables module checking).
     if symbol.kind == "module":
+        display = module_display_name(file_path)
         return Finding(
             file=file_path,
             line=symbol.line,
-            symbol=symbol.name,
+            symbol=display,
             rule="missing-examples",
-            message=f"Module '{symbol.name}' has no Examples: section",
+            message=f"Module '{display}' has no Examples: section",
             category="recommended",
         )
 
@@ -1133,11 +1137,12 @@ def _check_missing_cross_references(
     Two detection branches:
 
     - **Branch A:** Any module with no ``See Also:`` section at all — the
-      module should cross-reference related modules.
+      module should cross-reference related modules.  Uses module display
+      name in findings.
     - **Branch B:** Any symbol with a ``See Also:`` section whose content
       lacks linkable cross-reference syntax (Markdown bracket references
-      or Sphinx roles). Plain backtick identifiers do not satisfy the
-      rule because they render as inline code without a hyperlink.
+      or Sphinx roles).  Module-kind symbols use the display name;
+      others use ``symbol.name``.
 
     Args:
         symbol: The documented symbol to inspect.
@@ -1156,12 +1161,13 @@ def _check_missing_cross_references(
     # Branch A: module missing See Also: entirely
     if symbol.kind == "module":
         if _SEE_ALSO not in sections:
+            display = module_display_name(file_path)
             return Finding(
                 file=file_path,
                 line=symbol.line,
-                symbol=symbol.name,
+                symbol=display,
                 rule="missing-cross-references",
-                message=(f"Module '{symbol.name}' has no See Also: section"),
+                message=(f"Module '{display}' has no See Also: section"),
                 category="recommended",
             )
 
@@ -1182,13 +1188,16 @@ def _check_missing_cross_references(
         if _XREF_MD_LINK.search(line) or _XREF_SPHINX.search(line):
             return None
 
+    display_name = (
+        module_display_name(file_path) if symbol.kind == "module" else symbol.name
+    )
     return Finding(
         file=file_path,
         line=symbol.line,
-        symbol=symbol.name,
+        symbol=display_name,
         rule="missing-cross-references",
         message=(
-            f"See Also: section in {kind_display} '{symbol.name}' "
+            f"See Also: section in {kind_display} '{display_name}' "
             f"lacks cross-reference syntax"
         ),
         category="recommended",
@@ -1239,9 +1248,8 @@ def _check_prefer_fenced_code_blocks(
     Checks for ``>>>`` doctest patterns and ``::`` reStructuredText
     indented code blocks in the ``Examples:`` section content.  The
     ``>>>`` scan runs first; ``::`` detection fires only when no
-    doctest pattern is found.  Only applies when the ``Examples:``
-    section exists — absence is handled by the ``missing-examples``
-    rule.
+    doctest pattern is found.  Module-kind symbols use the display
+    name; others use ``symbol.name``.
 
     Args:
         symbol: The documented symbol to inspect.
@@ -1267,6 +1275,9 @@ def _check_prefer_fenced_code_blocks(
         return None
 
     kind_display = _SYMBOL_KIND_DISPLAY.get(symbol.kind, symbol.kind)
+    display_name = (
+        module_display_name(file_path) if symbol.kind == "module" else symbol.name
+    )
 
     lines = content.splitlines()
 
@@ -1275,10 +1286,10 @@ def _check_prefer_fenced_code_blocks(
             return Finding(
                 file=file_path,
                 line=symbol.line,
-                symbol=symbol.name,
+                symbol=display_name,
                 rule="prefer-fenced-code-blocks",
                 message=(
-                    f"Examples: section in {kind_display} '{symbol.name}' "
+                    f"Examples: section in {kind_display} '{display_name}' "
                     f"uses doctest format (>>>) instead of fenced code blocks"
                 ),
                 category="recommended",
@@ -1289,10 +1300,10 @@ def _check_prefer_fenced_code_blocks(
             return Finding(
                 file=file_path,
                 line=symbol.line,
-                symbol=symbol.name,
+                symbol=display_name,
                 rule="prefer-fenced-code-blocks",
                 message=(
-                    f"Examples: section in {kind_display} '{symbol.name}' "
+                    f"Examples: section in {kind_display} '{display_name}' "
                     f"uses reStructuredText indented code block (::) "
                     f"instead of fenced code blocks"
                 ),
@@ -1312,8 +1323,8 @@ def _check_fenced_code_blocks_extra(
     When ``_check_prefer_fenced_code_blocks`` finds one pattern type
     (doctest ``>>>`` or rST ``::``), this helper checks whether the
     *other* pattern type also exists in the same ``Examples:`` section.
-    This avoids a whack-a-mole cycle where the user fixes one pattern,
-    reruns, and only then discovers the second.
+    Module-kind symbols use the display name; others use
+    ``symbol.name``.
 
     Args:
         symbol: The documented symbol to inspect.
@@ -1333,6 +1344,9 @@ def _check_fenced_code_blocks_extra(
         return None
 
     kind_display = _SYMBOL_KIND_DISPLAY.get(symbol.kind, symbol.kind)
+    display_name = (
+        module_display_name(file_path) if symbol.kind == "module" else symbol.name
+    )
     lines = content.splitlines()
 
     if pattern_type == "doctest":
@@ -1342,10 +1356,10 @@ def _check_fenced_code_blocks_extra(
                 return Finding(
                     file=file_path,
                     line=symbol.line,
-                    symbol=symbol.name,
+                    symbol=display_name,
                     rule="prefer-fenced-code-blocks",
                     message=(
-                        f"Examples: section in {kind_display} '{symbol.name}' "
+                        f"Examples: section in {kind_display} '{display_name}' "
                         f"uses reStructuredText indented code block (::) "
                         f"instead of fenced code blocks"
                     ),
@@ -1358,10 +1372,10 @@ def _check_fenced_code_blocks_extra(
                 return Finding(
                     file=file_path,
                     line=symbol.line,
-                    symbol=symbol.name,
+                    symbol=display_name,
                     rule="prefer-fenced-code-blocks",
                     message=(
-                        f"Examples: section in {kind_display} '{symbol.name}' "
+                        f"Examples: section in {kind_display} '{display_name}' "
                         f"uses doctest format (>>>) instead of fenced code blocks"
                     ),
                     category="recommended",

--- a/src/docvet/checks/freshness.py
+++ b/src/docvet/checks/freshness.py
@@ -2,7 +2,9 @@
 
 Detects code changes that may have made docstrings stale. Diff mode maps
 git diff hunks to AST symbols; drift mode uses git blame age comparison.
-Implements Layer 4 of the docstring quality model.
+Module-kind findings use :func:`~docvet.ast_utils.module_display_name`
+for human-readable symbol names.  Implements Layer 4 of the docstring
+quality model.
 
 Examples:
     Run the freshness diff check on a file:
@@ -26,7 +28,7 @@ import time
 from datetime import datetime, timezone
 from typing import Literal
 
-from docvet.ast_utils import Symbol, map_lines_to_symbols
+from docvet.ast_utils import Symbol, map_lines_to_symbols, module_display_name
 from docvet.checks._finding import Finding
 from docvet.config import FreshnessConfig
 
@@ -64,6 +66,9 @@ def _build_finding(
 ) -> Finding:
     """Construct a Finding from freshness detection results.
 
+    Module-kind symbols use :func:`~docvet.ast_utils.module_display_name`
+    for the ``symbol`` field; others use ``symbol.name``.
+
     Args:
         file_path: Source file path where the finding was detected.
         symbol: The symbol whose docstring is potentially stale.
@@ -74,10 +79,11 @@ def _build_finding(
     Returns:
         A Finding with fields mapped from the symbol and arguments.
     """
+    display = module_display_name(file_path) if symbol.kind == "module" else symbol.name
     return Finding(
         file=file_path,
         line=symbol.line,
-        symbol=symbol.name,
+        symbol=display,
         rule=rule,
         message=message,
         category=category,
@@ -203,7 +209,8 @@ def check_freshness_diff(
 
     Maps changed lines from the diff to AST symbols, classifies the
     change type, and produces findings for symbols whose docstrings
-    were not updated alongside code changes.
+    were not updated alongside code changes.  Module-kind symbols
+    use the dotted display name in messages.
 
     Args:
         file_path: Source file path for finding attribution.
@@ -241,8 +248,11 @@ def check_freshness_diff(
 
         rule, category = _CLASSIFICATION_MAP[classification]
         kind = symbol.kind.capitalize()
+        display = (
+            module_display_name(file_path) if symbol.kind == "module" else symbol.name
+        )
         message = (
-            f"{kind} '{symbol.name}' {classification} changed but docstring not updated"
+            f"{kind} '{display}' {classification} changed but docstring not updated"
         )
         findings.append(_build_finding(file_path, symbol, rule, message, category))
 
@@ -419,7 +429,7 @@ def _build_drift_finding(
     doc_ts: list[int],
     file_path: str,
 ) -> Finding:
-    """Construct a drift finding for a symbol whose code outpaced its docstring.
+    """Construct a drift finding for a symbol whose code outpaced its docs.
 
     Args:
         sym: The symbol with stale docstring.
@@ -436,8 +446,9 @@ def _build_drift_finding(
     doc_date = datetime.fromtimestamp(doc_max, tz=timezone.utc).date().isoformat()
     days = (code_max - doc_max) // 86400
     kind = sym.kind.capitalize()
+    display = module_display_name(file_path) if sym.kind == "module" else sym.name
     message = (
-        f"{kind} '{sym.name}' code modified {code_date}, "
+        f"{kind} '{display}' code modified {code_date}, "
         f"docstring last modified {doc_date} ({days} days drift)"
     )
     return _build_finding(file_path, sym, "stale-drift", message, "recommended")
@@ -449,7 +460,7 @@ def _build_age_finding(
     effective_now: int,
     file_path: str,
 ) -> Finding:
-    """Construct an age finding for a symbol with an untouched docstring.
+    """Construct an age finding for a symbol with an unchanged docstring.
 
     Args:
         sym: The symbol with aged docstring.
@@ -464,7 +475,8 @@ def _build_age_finding(
     doc_date = datetime.fromtimestamp(doc_max, tz=timezone.utc).date().isoformat()
     days = (effective_now - doc_max) // 86400
     kind = sym.kind.capitalize()
-    message = f"{kind} '{sym.name}' docstring untouched since {doc_date} ({days} days)"
+    display = module_display_name(file_path) if sym.kind == "module" else sym.name
+    message = f"{kind} '{display}' docstring untouched since {doc_date} ({days} days)"
     return _build_finding(file_path, sym, "stale-age", message, "recommended")
 
 

--- a/src/docvet/checks/presence.py
+++ b/src/docvet/checks/presence.py
@@ -2,9 +2,10 @@
 
 Detects public symbols (modules, classes, functions, methods) that lack
 a docstring, and reports per-file coverage statistics via
-:class:`PresenceStats`. Uses stdlib ``ast`` only — no runtime
-dependencies beyond what docvet already requires. Complements ruff
-D100–D107 by adding coverage metrics and pipeline integration.
+:class:`PresenceStats`.  Module-kind findings use
+:func:`~docvet.ast_utils.module_display_name` for human-readable
+symbol names.  Complements ruff D100–D107 by adding coverage metrics
+and pipeline integration.
 
 Examples:
     Run the presence check on a source string:
@@ -26,7 +27,7 @@ from __future__ import annotations
 import ast
 from dataclasses import dataclass
 
-from docvet.ast_utils import Symbol, get_documented_symbols
+from docvet.ast_utils import Symbol, get_documented_symbols, module_display_name
 from docvet.checks._finding import Finding
 from docvet.config import PresenceConfig
 
@@ -100,9 +101,9 @@ def check_presence(
 
     Parses *source* into an AST, extracts all documentable symbols via
     :func:`~docvet.ast_utils.get_documented_symbols`, applies the
-    filtering rules from *config*, and returns one
-    :class:`~docvet.checks._finding.Finding` per undocumented symbol
-    together with per-file coverage statistics.
+    filtering rules from *config*, and returns one finding per
+    undocumented symbol together with per-file coverage statistics.
+    Module symbols use the dotted display name in findings.
 
     Args:
         source: Raw Python source text.
@@ -142,15 +143,17 @@ def check_presence(
 
         # Build message: module is special, others get "Public" prefix.
         if symbol.kind == "module":
-            message = "Module has no docstring"
+            display = module_display_name(file_path)
+            message = f"Module '{display}' has no docstring"
         else:
+            display = symbol.name
             message = f"Public {symbol.kind} has no docstring"
 
         findings.append(
             Finding(
                 file=file_path,
                 line=symbol.line,
-                symbol=symbol.name,
+                symbol=display,
                 rule="missing-docstring",
                 message=message,
                 category="required",

--- a/tests/unit/checks/test_coverage.py
+++ b/tests/unit/checks/test_coverage.py
@@ -35,7 +35,7 @@ class TestCheckCoverageBasicDetection:
         assert len(findings) == 1
         assert findings[0].file == str(module).replace("\\", "/")
         assert findings[0].line == 1
-        assert findings[0].symbol == "<module>"
+        assert findings[0].symbol == "pkg.sub"
         assert findings[0].rule == "missing-init"
         assert findings[0].category == "required"
         assert "pkg/sub" in findings[0].message
@@ -326,7 +326,7 @@ class TestCheckCoverageFindingFields:
         assert isinstance(f, Finding)
         assert f.file == str(module).replace("\\", "/")
         assert f.line == 1
-        assert f.symbol == "<module>"
+        assert f.symbol == "pkg"
         assert f.rule == "missing-init"
         assert f.category == "required"
         assert f.message == "Directory 'pkg' lacks __init__.py (1 file affected)"

--- a/tests/unit/checks/test_enrichment.py
+++ b/tests/unit/checks/test_enrichment.py
@@ -2873,9 +2873,9 @@ FOO = 42
     assert result is not None
     assert result.file == "regular.py"
     assert result.line == 1
-    assert result.symbol == "<module>"
+    assert result.symbol == "regular"
     assert result.rule == "missing-examples"
-    assert result.message == "Module '<module>' has no Examples: section"
+    assert result.message == "Module 'regular' has no Examples: section"
     assert result.category == "recommended"
 
 
@@ -3069,9 +3069,9 @@ FOO = 42
     assert len(missing_examples) == 1
     assert missing_examples[0].file == "regular.py"
     assert missing_examples[0].line == 1
-    assert missing_examples[0].symbol == "<module>"
+    assert missing_examples[0].symbol == "regular"
     assert missing_examples[0].rule == "missing-examples"
-    assert missing_examples[0].message == "Module '<module>' has no Examples: section"
+    assert missing_examples[0].message == "Module 'regular' has no Examples: section"
     assert missing_examples[0].category == "recommended"
 
 
@@ -3237,7 +3237,7 @@ FOO = 42
     assert isinstance(result, Finding)
     assert result.rule == "missing-cross-references"
     assert result.category == "recommended"
-    assert result.message == "Module '<module>' has no See Also: section"
+    assert result.message == "Module '__init__' has no See Also: section"
 
 
 def test_cross_refs_when_non_init_module_no_see_also_returns_finding():
@@ -3263,9 +3263,9 @@ FOO = 42
     assert result is not None
     assert result.file == "regular.py"
     assert result.line == 1
-    assert result.symbol == "<module>"
+    assert result.symbol == "regular"
     assert result.rule == "missing-cross-references"
-    assert result.message == "Module '<module>' has no See Also: section"
+    assert result.message == "Module 'regular' has no See Also: section"
     assert result.category == "recommended"
 
 
@@ -3324,7 +3324,7 @@ FOO = 42
 
     assert result is not None
     assert result.rule == "missing-cross-references"
-    assert result.symbol == "<module>"
+    assert result.symbol == "regular"
     assert result.category == "recommended"
     assert "lacks cross-reference syntax" in result.message
 
@@ -3395,7 +3395,7 @@ FOO = 42
     assert result is not None
     assert result.file == "regular.py"
     assert result.line == 1
-    assert result.symbol == "<module>"
+    assert result.symbol == "regular"
     assert result.rule == "missing-cross-references"
     assert "lacks cross-reference syntax" in result.message
     assert result.category == "recommended"
@@ -3595,7 +3595,7 @@ FOO = 42
 
     xref_findings = [f for f in findings if f.rule == "missing-cross-references"]
     assert len(xref_findings) == 1
-    assert xref_findings[0].message == "Module '<module>' has no See Also: section"
+    assert xref_findings[0].message == "Module '__init__' has no See Also: section"
 
 
 def test_cross_refs_when_init_module_has_backtick_see_also_returns_finding():
@@ -3624,7 +3624,7 @@ FOO = 42
 
     assert result is not None
     assert result.rule == "missing-cross-references"
-    assert result.symbol == "<module>"
+    assert result.symbol == "__init__"
     assert result.category == "recommended"
     assert "lacks cross-reference syntax" in result.message
 

--- a/tests/unit/checks/test_freshness.py
+++ b/tests/unit/checks/test_freshness.py
@@ -1696,3 +1696,31 @@ class TestCheckFreshnessDrift:
         assert len(findings) >= 2
         lines = [f.line for f in findings]
         assert lines == sorted(lines)
+
+
+class TestModuleDisplayNameInFindings:
+    """Module-level findings use display name, not ``<module>`` sentinel."""
+
+    def test_diff_mode_module_body_change_uses_display_name(self) -> None:
+        source = '''\
+"""Module docstring."""
+
+import os
+
+x = 1
+'''
+        tree = ast.parse(source)
+        diff = (
+            "diff --git a/test.py b/test.py\n"
+            "--- a/test.py\n"
+            "+++ b/test.py\n"
+            "@@ -4,1 +4,1 @@\n"
+            "-import os\n"
+            "+import sys\n"
+        )
+        findings = check_freshness_diff("src/pkg/test.py", diff, tree)
+        assert len(findings) == 1
+        assert findings[0].symbol == "pkg.test"
+        assert "Module 'pkg.test'" in findings[0].message
+        assert "<module>" not in findings[0].symbol
+        assert "<module>" not in findings[0].message

--- a/tests/unit/checks/test_presence.py
+++ b/tests/unit/checks/test_presence.py
@@ -87,9 +87,9 @@ def foo():
 """
         findings, _ = check_presence(source, "mod.py", PresenceConfig())
 
-        module_findings = [f for f in findings if f.symbol == "<module>"]
+        module_findings = [f for f in findings if f.symbol == "mod"]
         assert len(module_findings) == 1
-        assert module_findings[0].message == "Module has no docstring"
+        assert module_findings[0].message == "Module 'mod' has no docstring"
         assert module_findings[0].line == 1
 
     def test_present_module_docstring_no_finding(self) -> None:
@@ -100,7 +100,7 @@ import os
 '''
         findings, _ = check_presence(source, "mod.py", PresenceConfig())
 
-        module_findings = [f for f in findings if f.symbol == "<module>"]
+        module_findings = [f for f in findings if f.symbol == "mod"]
         assert module_findings == []
 
 
@@ -438,9 +438,9 @@ import sys
         findings, stats = check_presence(source, "imports.py", PresenceConfig())
 
         # Module symbol exists but has no docstring
-        module_findings = [f for f in findings if f.symbol == "<module>"]
+        module_findings = [f for f in findings if f.symbol == "imports"]
         assert len(module_findings) == 1
-        assert module_findings[0].message == "Module has no docstring"
+        assert module_findings[0].message == "Module 'imports' has no docstring"
         assert stats.total == 1
         assert stats.documented == 0
 
@@ -523,9 +523,9 @@ class Foo:
         source = "x = 1\n"
         findings, _ = check_presence(source, "app.py", PresenceConfig())
 
-        module_findings = [f for f in findings if f.symbol == "<module>"]
+        module_findings = [f for f in findings if f.symbol == "app"]
         assert len(module_findings) == 1
-        assert module_findings[0].message == "Module has no docstring"
+        assert module_findings[0].message == "Module 'app' has no docstring"
 
 
 # ---------------------------------------------------------------------------
@@ -593,7 +593,7 @@ import os
 """
         findings, _ = check_presence(source, "script.py", PresenceConfig())
 
-        module_findings = [f for f in findings if f.symbol == "<module>"]
+        module_findings = [f for f in findings if f.symbol == "script"]
         assert len(module_findings) == 1
 
     def test_file_with_coding_pragma_and_no_docstring(self) -> None:
@@ -604,7 +604,7 @@ import os
 """
         findings, _ = check_presence(source, "legacy.py", PresenceConfig())
 
-        module_findings = [f for f in findings if f.symbol == "<module>"]
+        module_findings = [f for f in findings if f.symbol == "legacy"]
         assert len(module_findings) == 1
 
     def test_stats_consistency_across_mixed_file(self) -> None:

--- a/tests/unit/test_ast_utils.py
+++ b/tests/unit/test_ast_utils.py
@@ -11,6 +11,7 @@ from docvet.ast_utils import (
     get_documented_symbols,
     get_signature_range,
     map_lines_to_symbols,
+    module_display_name,
 )
 
 pytestmark = pytest.mark.unit
@@ -442,3 +443,29 @@ class TestMapLinesToSymbols:
         line_map = map_lines_to_symbols(tree)
         assert line_map[1].kind == "module"
         assert line_map[3].kind == "module"
+
+
+class TestModuleDisplayName:
+    """Tests for ``module_display_name()``."""
+
+    @pytest.mark.parametrize(
+        ("file_path", "expected"),
+        [
+            ("src/pkg/mod.py", "pkg.mod"),
+            ("pkg/mod.py", "pkg.mod"),
+            ("mod.py", "mod"),
+            ("src/pkg/__init__.py", "pkg"),
+            ("__init__.py", "__init__"),
+            ("lib/pkg/mod.py", "pkg.mod"),
+            ("src/a/b/c.py", "a.b.c"),
+            ("src/pkg/sub/__init__.py", "pkg.sub"),
+            ("src\\pkg\\mod.py", "pkg.mod"),
+            ("/home/user/project/src/pkg/mod.py", "pkg.mod"),
+            ("/opt/lib/pkg/mod.py", "pkg.mod"),
+            ("/home/user/project/pkg/mod.py", "home.user.project.pkg.mod"),
+            ("", "<module>"),
+            ("Makefile", "Makefile"),
+        ],
+    )
+    def test_conversion(self, file_path: str, expected: str) -> None:
+        assert module_display_name(file_path) == expected

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1064,7 +1064,7 @@ def test_run_coverage_when_files_have_missing_init_prints_formatted_output(mocke
         Finding(
             file="src/pkg/sub/module.py",
             line=1,
-            symbol="<module>",
+            symbol="pkg.sub",
             rule="missing-init",
             message="Directory 'pkg/sub' lacks __init__.py (1 file affected)",
             category="required",
@@ -1130,7 +1130,7 @@ def test_check_command_includes_coverage_findings(mocker):
         Finding(
             file="src/pkg/mod.py",
             line=1,
-            symbol="<module>",
+            symbol="pkg",
             rule="missing-init",
             message="Directory 'pkg' lacks __init__.py (1 file affected)",
             category="required",
@@ -1518,7 +1518,7 @@ def test_run_coverage_direct_returns_list_of_findings(mocker):
         Finding(
             file="src/pkg/mod.py",
             line=1,
-            symbol="<module>",
+            symbol="pkg",
             rule="missing-init",
             message="Directory 'pkg' lacks __init__.py (1 file affected)",
             category="required",
@@ -1531,7 +1531,7 @@ def test_run_coverage_direct_returns_list_of_findings(mocker):
     assert result[0].rule == "missing-init"
     assert result[0].file == "src/pkg/mod.py"
     assert result[0].line == 1
-    assert result[0].symbol == "<module>"
+    assert result[0].symbol == "pkg"
     assert result[0].message == "Directory 'pkg' lacks __init__.py (1 file affected)"
     assert result[0].category == "required"
     assert pkg_count == 1


### PR DESCRIPTION
Module-level findings used the AST sentinel `<module>` in both the `symbol` field and `message` text of Finding records. In CI logs and GitHub Actions annotations, this produced dozens of identical, untriageable lines like `Module '<module>' has no See Also: section` with no indication of which file was affected. Discovered via real-world usage of `docvet@v1` GitHub Action in `gepa-adk` CI.

- Add `module_display_name()` helper to `ast_utils.py` with rfind-based absolute path support, backslash normalization, and `__init__` collapsing
- Update 8 enrichment callsites (3 module-branched + 5 generic) to use display names for module-kind findings
- Update presence symbol and message to include module display name (e.g., `Module 'app' has no docstring`)
- Update freshness `_build_finding` and 3 message construction sites with conditional display name
- Replace coverage hardcoded `symbol="<module>"` with `dir_rel.replace("/", ".")` for dotted package names
- Add 15 helper edge-case tests and 1 new freshness module-level finding test
- Update 23 existing test assertions across 5 test files

Test: `uv run pytest -v`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- `module_display_name()` edge cases: absolute paths, Windows backslashes, bare `__init__.py`, flat-layout projects without `src/`
- Generic enrichment callsites use conditional `module_display_name(file_path) if symbol.kind == "module" else symbol.name` — non-module behavior must be unchanged

### Related
- Triggered by: https://github.com/Alberto-Codes/gepa-adk/actions/runs/22805146741/job/66152955041