### PR TITLE
fix(docs): wrap GitHub Actions code blocks with raw tags

### DIFF
--- a/docs/site/ci-integration.md
+++ b/docs/site/ci-integration.md
@@ -94,6 +94,7 @@ The action sets step outputs that downstream steps can consume:
 
 To consume outputs, give the docvet step an `id` and reference its outputs in later steps:
 
+{% raw %}
 ```yaml
 - uses: Alberto-Codes/docvet@v1
   id: docvet
@@ -101,6 +102,7 @@ To consume outputs, give the docvet step an `id` and reference its outputs in la
     checks: "all"
 - run: echo "docvet found ${{ steps.docvet.outputs.total_findings }} issues"
 ```
+{% endraw %}
 
 Outputs are only set in new mode (`checks` input). Legacy mode (`args` input) does not produce outputs.
 
@@ -237,6 +239,7 @@ For teams that want a live badge showing pass/fail status from the latest CI run
 
 3. **Add the badge step** to your workflow after the docvet action:
 
+    {% raw %}
     ```yaml
     jobs:
       docvet:
@@ -259,6 +262,7 @@ For teams that want a live badge showing pass/fail status from the latest CI run
               message: ${{ steps.docvet.outputs.badge_message || 'error' }}
               color: ${{ steps.docvet.outputs.badge_color || 'lightgrey' }}
     ```
+    {% endraw %}
 
 4. **Add the badge to your README**:
 


### PR DESCRIPTION
The `${{ }}` expressions in ci-integration.md YAML code blocks were
being interpreted by mkdocs-macros' Jinja engine, causing `mkdocs build
--strict` failures in the Deploy Documentation workflow. Introduced in
4e4a09a (badge outputs docs, PR #313).

- Wrap two YAML code blocks containing `${{ }}` with `{% raw %}` / `{% endraw %}`

Test: `uv run mkdocs build --strict`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Docs-only change — two `{% raw %}` wrappers around GitHub Actions YAML code blocks.

### Related
- PR #313 introduced the badge docs with `${{ }}` expressions