### PR TITLE
fix(cli): catch ImportError in mcp command for missing extras

### DIFF
--- a/src/docvet/cli.py
+++ b/src/docvet/cli.py
@@ -1372,13 +1372,15 @@ def mcp() -> None:
     Launches a Model Context Protocol server on stdio that exposes
     docstring quality checks as MCP tools for AI agents.
     Requires the ``[mcp]`` extra (``pip install docvet[mcp]``).
+    Catches both ``ModuleNotFoundError`` and ``ImportError`` to
+    handle re-raised import failures gracefully.
 
     Raises:
         typer.Exit: If required MCP dependencies are not installed.
     """
     try:
         from docvet.mcp import start_server as mcp_start_server
-    except ModuleNotFoundError:
+    except ImportError:
         typer.echo(
             "MCP server requires the mcp extra: pip install docvet[mcp]",
             err=True,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2849,6 +2849,22 @@ class TestMcpSubcommand:
         assert result.exit_code == 1
         assert "pip install docvet[mcp]" in result.output
 
+    def test_import_error_shows_friendly_message(self, mocker):
+        """ImportError (not just ModuleNotFoundError) is caught gracefully."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "docvet.mcp":
+                raise ImportError("MCP server requires the mcp extra")
+            return real_import(name, *args, **kwargs)
+
+        mocker.patch("builtins.__import__", side_effect=fake_import)
+        result = runner.invoke(app, ["mcp"])
+        assert result.exit_code == 1
+        assert "pip install docvet[mcp]" in result.output
+
     def test_successful_invocation_calls_start_server(self, mocker):
         """Successful import calls start_server once."""
         mock_start = mocker.patch("docvet.mcp.start_server")


### PR DESCRIPTION
Running `docvet mcp` without the `[mcp]` extra installed showed a raw
Python traceback instead of a friendly error message. The `mcp.py`
module catches `ModuleNotFoundError` and re-raises as `ImportError`,
but the CLI handler only caught `ModuleNotFoundError`.

- Broaden except clause from `ModuleNotFoundError` to `ImportError`
- Add test covering the `ImportError` (not just `ModuleNotFoundError`) path

Test: `uv run pytest tests/unit/test_cli.py::TestMcpSubcommand -v`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
One-line fix in cli.py + one new test. The lsp command already handles this correctly.

### Related
Discovered during UX journey testing of all install variants.