### PR TITLE
chore(planning): add Epics 34-35 and update sprint status

### DIFF
--- a/_bmad-output/implementation-artifacts/epic-31-retro-2026-03-07.md
+++ b/_bmad-output/implementation-artifacts/epic-31-retro-2026-03-07.md
@@ -1,0 +1,123 @@
+# Epic 31 Retrospective — Project Health Visibility
+
+**Date:** 2026-03-07
+**Facilitator:** Bob (Scrum Master)
+**Participants:** Alberto-Codes (Project Lead), Alice (Product Owner), Charlie (Senior Dev), Dana (QA Engineer), Elena (Junior Dev)
+
+---
+
+## Epic Summary
+
+| Metric | Value |
+|--------|-------|
+| Stories | 3/3 completed (100%) |
+| Story types | 1 CI/infrastructure, 1 CLI feature, 1 CLI feature |
+| Debug sessions | 0 (zero-debug streak continues: 33+ stories) |
+| Test count | 1290 (up from 1208, +82 net new) |
+| Code review findings | 31.1: 1H+2M+2L, 31.2: 0 (review not completed), 31.3: 2H+2M+2L — all HIGH/MEDIUM resolved |
+| Tech debt items | 0 new |
+| Production incidents | 0 |
+| Stories cut | 0 |
+
+### Stories
+
+| Story | Title | Type | Debug Sessions | Review Findings |
+|-------|-------|------|---------------|-----------------|
+| 31.1 | Dynamic Badge Endpoint | CI/Infrastructure | 0 | 1H+2M+2L — fixes applied + party-mode dismissals |
+| 31.2 | Summary Flag for Quality Percentages | CLI Feature | 0 | Review section unfilled (status: review) |
+| 31.3 | Config Show-Defaults Command | CLI Feature | 0 | 2H+2M+2L — all resolved |
+
+---
+
+## Successes
+
+- **Three-for-three delivery with zero debug sessions** — all 3 stories completed, extending the zero-debug streak to 33+ stories. Story specs remain the #1 velocity multiplier.
+- **`docvet config` command adds real discoverability** — users can now see their effective configuration with source annotations (`# (user)` / `# (default)`). TOML roundtrip correctness (AC 5) ensures copy-paste reliability. Party-mode consensus drove the "no flags required" design.
+- **`--summary` flag fills a unique gap** — per-check quality percentages with no composite score (party-mode consensus backed by research: Pylint's composite score is its most complained-about feature). JSON integration preserves machine consumption path.
+- **Party-mode consensus matured further** — all 3 stories had party-mode input: badge strategy (31.1 → static vs dynamic), no-composite-score (31.2), no-required-flag (31.3). Every decision was unanimous or near-unanimous.
+- **Code review caught real HIGH issues** — 31.1: stale file list after Task 4 revert. 31.3: cognitive complexity 33 and 16 in new formatters. Both were fixed before merge.
+- **Test maturity piggyback applied** — 31.2 added `# Should not raise` comments to test_config.py. 31.3 identified P3 test_mcp.py consolidation (deferred as appropriate).
+- **Interrogate supersession completed organically** — 31.3 removed all stale interrogate references across AGENTS.md, CLAUDE.md, project-context.md, story template, pyproject.toml, and enrichment.py. docvet's own presence check now fully replaces interrogate.
+
+---
+
+## Challenges
+
+- **Story 31.2 code review not completed** — status is "review" but the Code Review section is empty (no reviewer, no findings, no verification). This is the same story-file-discipline pattern from Epic 30.
+- **`_run_*` return type change rippled through ~30 existing tests** — Story 31.2 changed all `_run_*` functions from `list[Finding]` to `tuple[list[Finding], int]`. While the change was clean, updating 30 existing tests for mock return values was mechanical churn. The tuple-return pattern is now established but wasn't anticipated in the original design.
+- **Cognitive complexity in new formatters (31.3)** — `format_config_toml` hit CC 33 and `format_config_json` hit CC 16, both caught by code review. Required extracting 5 helper functions. Manual TOML serialization inherently branches on types/conditions.
+- **One manual task remains incomplete** — 31.1 Task 4.4 (create Gist + add GIST_SECRET for docvet's own CI) is marked as optional/manual/post-merge but is still unchecked. The badge infrastructure is built but not activated for docvet itself.
+
+---
+
+## Key Insights
+
+1. **Return-type changes ripple — design tuples from the start** — The `_run_*` → tuple change in 31.2 required updating 30 tests. When designing check runner interfaces, anticipate metadata alongside results. The tuple pattern is now precedent for any future check runner.
+
+2. **Manual TOML serialization is CC-expensive** — Without `tomli_w`, manual formatting requires per-type branching, nested section handling, and annotation logic. The 5-helper extraction was the right fix, but if config grows significantly, a TOML writer library may become justified.
+
+3. **Removing dead tool references needs a sweep, not spot fixes** — 31.3's interrogate cleanup touched 7 files across docs, templates, and config. A one-time "grep and replace" sweep is more reliable than finding references during unrelated stories.
+
+4. **Party-mode consensus is now the standard for design decisions** — 3/3 stories used it. The pattern is: research (competitors, standards), debate, vote, document. Consensus decisions have had zero reversals.
+
+---
+
+## Previous Retro Follow-Through (Epic 30)
+
+| # | Action Item | Status |
+|---|------------|--------|
+| 1 | Document GitHub Action annotation limits in dev notes | **Done** — 31.1 story file documents 10/step, 50/job caps and `$GITHUB_STEP_SUMMARY` fallback in Dev Notes |
+| 2 | Drop story-file-completeness enforcement as retro action | **Done** — no longer tracked as retro item |
+| 3 | Continue test maturity piggyback pattern | **Done** — 31.2 applied it (P3 comments), 31.3 identified but deferred appropriately |
+
+**Follow-through: 3/3**
+
+**Follow-through trend:** 4/4 → 2/4 → 1/4 → 3/3 → 3/3 → 3/3 → 3/3 → 4/6 → 7/8 → 2/2 → 1/1 → 2/2 → 2/2 → ~1.5/2 → **3/3**
+
+---
+
+## Next Epic Preview
+
+**Epic 32: Linter Lifecycle — Fix & Suppress** (backlog) and the newly planned **Epics 34-35: Multi-Style Support & Enrichment Expansion** (from boto3 validation). Epic 34 adds Sphinx/NumPy support + missing-returns + missing-param agreement. Epic 35 adds depth rules (deprecation, naming, type agreement, note/warning sections). These target the darglint vacuum and unlock adoption for non-Google-style codebases.
+
+---
+
+## Action Items
+
+### Process Improvements
+
+1. **Complete 31.2 code review before closing the epic**
+   - Owner: Dev agent
+   - Success criteria: 31.2 story file has filled Reviewer, Outcome, Findings Summary, and Verification sections
+   - Rationale: Story was marked "done" in sprint-status but code review section is empty
+
+2. **Continue test maturity piggyback pattern**
+   - Owner: Dev agent (standard practice)
+   - Success criteria: When modifying tests for a story, evaluate if extraction/reorganization is natural
+
+### Technical Debt
+
+None new. The P3 test_mcp.py consolidation from 31.3 is a future housekeeping candidate, not a retro commitment.
+
+### Team Agreements
+
+- Party-mode consensus remains the standard for design decisions (3/3 adoption in Epic 31)
+- Tuple return types for check runners are the established pattern — no more `list[Finding]`-only returns
+- Test maturity piggyback continues as standard practice
+
+---
+
+## Readiness Assessment
+
+| Area | Status |
+|------|--------|
+| Testing & Quality | 1290 tests, 100% docvet coverage, zero-debug streak 33+ |
+| Deployment | Live on PyPI v1.12.1, auto-publish CI pipeline, dynamic badge infrastructure ready |
+| Technical Health | Stable, zero new debt, CC clean after code review fixes |
+| Unresolved Blockers | None |
+
+---
+
+## Project Arc Summary
+
+Epic 31 completes Project Health Visibility: 31 epics, 86 stories, 1290 tests. docvet now offers at-a-glance health metrics (`--summary`), dynamic CI badges (infrastructure ready, activation optional), and full config introspection (`docvet config`). The interrogate dependency is fully superseded. Next wave: Epics 34-35 (multi-style enrichment expansion from boto3 validation) or Epic 32 (fix & suppress lifecycle).

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -258,11 +258,11 @@ development_status:
   epic-30-retrospective: done  # 2026-03-06
 
   # Epic 31: Project Health Visibility
-  epic-31: in-progress
+  epic-31: done
   31-1-dynamic-badge-endpoint: done
   31-2-summary-flag-for-quality-percentages: done
-  31-3-config-show-defaults-command: review
-  epic-31-retrospective: optional
+  31-3-config-show-defaults-command: done  # 2026-03-07 — merged as `docvet config` command
+  epic-31-retrospective: done  # 2026-03-07
 
   # Epic 32: Linter Lifecycle -- Fix & Suppress
   epic-32: backlog
@@ -278,3 +278,21 @@ development_status:
   33-2-flagship-oss-runs-and-example-guide: backlog
   33-3-sarif-output-format: backlog
   epic-33-retrospective: optional
+
+  # Epic 34: Multi-Style Support & Foundation Rules
+  epic-34: backlog
+  34-1-sphinx-rst-docstring-style-support: backlog
+  34-2-missing-returns-enrichment-rule: backlog
+  34-3-numpy-style-section-recognition-phase-1: backlog
+  34-4-overload-has-docstring-check: backlog
+  epic-34-retrospective: optional
+
+  # Epic 35: Enrichment Depth — Correctness & Completeness Rules
+  epic-35: backlog
+  35-1-docstring-parameter-agreement-checks: backlog
+  35-2-missing-deprecation-enrichment-rule: backlog
+  35-3-reverse-enrichment-checks: backlog
+  35-4-trivial-docstring-enrichment-rule: backlog
+  35-5-missing-return-type-enrichment-rule: backlog
+  35-6-undocumented-init-params-enrichment-rule: backlog
+  epic-35-retrospective: optional

--- a/_bmad-output/implementation-artifacts/tech-spec-module-display-name-in-findings.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-module-display-name-in-findings.md
@@ -1,0 +1,252 @@
+---
+title: 'Replace <module> sentinel with Python module display names in findings'
+slug: 'module-display-name-in-findings'
+created: '2026-03-07'
+status: 'implementation-complete'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack: ['python', 'ast']
+files_to_modify: ['src/docvet/ast_utils.py', 'src/docvet/checks/enrichment.py', 'src/docvet/checks/presence.py', 'src/docvet/checks/freshness.py', 'src/docvet/checks/coverage.py']
+code_patterns: ['module_display_name helper', 'Finding symbol field', 'Finding message field']
+test_patterns: ['unit tests for helper edge cases', 'assertion updates for <module> sentinel']
+---
+
+# Tech-Spec: Replace `<module>` sentinel with Python module display names in findings
+
+**Created:** 2026-03-07
+
+## Overview
+
+### Problem Statement
+
+Module-level findings use the AST sentinel `<module>` in both the `symbol` field and `message` text of Finding records. In CI logs and GitHub Actions step summaries, this produces dozens of identical, untriageable lines like `Module '<module>' has no See Also: section` with no indication of which file is affected. The `file=` parameter in `::warning` annotations places findings on the correct file in the PR diff, but the message text itself is useless — especially in the log view where file context is absent, and in the step summary table where all module findings look identical.
+
+This was shipped in v1.0.0 and remains unfixed on `main` as of v1.0.2.
+
+### Solution
+
+Add a `module_display_name(file_path)` helper to `ast_utils.py` that converts file paths to dotted Python module names (e.g., `src/gepa_adk/config.py` -> `gepa_adk.config`). Use it in all four check modules for both the `symbol` and `message` fields on module-kind findings, replacing the `<module>` sentinel with a human-readable, Python-native identifier.
+
+### Scope
+
+**In Scope:**
+
+- New `module_display_name(file_path: str) -> str` public helper in `ast_utils.py`
+- Update all module-kind `symbol=` fields in enrichment (8 callsites: 3 module-branched + 5 generic), presence (1), freshness (1 in `_build_finding`), coverage (1)
+- Update all module-kind `message=` templates in enrichment (8 sites: 3 module-branched + 5 generic — same sites as `symbol=`), presence (1), and freshness (3 caller sites: diff mode, drift mode, age mode)
+- Unit tests for the helper (edge cases: `src/` prefix, no prefix, `__init__.py`, nested packages, `lib/` prefix, flat scripts)
+- Update 23 existing test assertions across 5 test files that match `"<module>"` or old message text
+- Add 1 new test: module-level freshness finding asserts display name in `symbol` and `message` fields (no existing tests cover this path)
+
+**Out of Scope:**
+
+- `ast_utils.py` Symbol constructor (`name="<module>"` stays — AST layer remains pure)
+- `action.yml` changes (annotation format is correct, only message text was broken)
+- New CLI flags or config options
+- Coverage message text (already uses directory path, not `symbol.name`)
+- `griffe_compat.py` — uses `obj.name` from griffe's own parser which provides real module names, not `<module>`
+
+## Context for Development
+
+### Codebase Patterns
+
+- Finding messages follow the pattern `{Kind} '{name}' has no {section} section` — functions use the function name, classes use the class name, modules should use the dotted module path
+- All `_check_*` functions in enrichment receive `file_path: str` as their last parameter — the data needed for conversion is already available at every callsite
+- `presence.py` and `freshness.py` also receive `file_path` at their check function level
+- `coverage.py` hardcodes `symbol="<module>"` directly in the Finding constructor; `representative` file path variable is available
+- The `Symbol` dataclass in `ast_utils.py` is frozen — the `name="<module>"` value is set at construction and cannot be mutated; conversion must happen at the consumer (check) layer
+- Enrichment has two categories of callsites: **module-branched** (guarded by `symbol.kind == "module"`) and **generic** (handle all kinds via `kind_display` lookup). Both need the fix — generic sites use a conditional: `module_display_name(file_path) if symbol.kind == "module" else symbol.name`
+- Freshness builds messages at 3 caller sites then passes them to `_build_finding`; the `symbol=` fix goes in `_build_finding`, the `message=` fix goes in each caller
+- `griffe_compat.py` uses `obj.name` from griffe's own parser — griffe provides real module names, not `<module>`, so no fix needed
+
+### Callsite Map
+
+**Enrichment (`enrichment.py`) — 8 `symbol=` + 8 `message=` sites:**
+
+| Lines | Rule | Kind guard | Notes |
+|-------|------|-----------|-------|
+| 926-933 | `missing-attributes` | `symbol.kind == "module"` + `_is_init_module` | Module-branched |
+| 1063-1070 | `missing-examples` | `symbol.kind == "module"` | Module-branched |
+| 1159-1166 | `missing-cross-references` Branch A | `symbol.kind == "module"` | Module-branched |
+| 1185-1195 | `missing-cross-references` Branch B | Any kind | Generic — uses `kind_display` |
+| 1275-1285 | `prefer-fenced-code-blocks` (doctest) | Any kind | Generic — uses `kind_display` |
+| 1289-1300 | `prefer-fenced-code-blocks` (RST) | Any kind | Generic — uses `kind_display` |
+| 1342-1353 | `prefer-fenced-code-blocks` extra (RST) | Any kind | Generic — uses `kind_display` |
+| 1358-1368 | `prefer-fenced-code-blocks` extra (doctest) | Any kind | Generic — uses `kind_display` |
+
+**Presence (`presence.py`) — 1 `symbol=` + 1 `message=` site:**
+
+| Lines | Notes |
+|-------|-------|
+| 144-157 | Message is `"Module has no docstring"` (doesn't use `symbol.name`); update to include display name. `symbol=symbol.name` needs fix. |
+
+**Freshness (`freshness.py`) — 1 `symbol=` + 3 `message=` sites:**
+
+| Lines | Rule | Notes |
+|-------|------|-------|
+| 77-84 | `_build_finding` helper | `symbol=symbol.name` — fix with conditional |
+| 244-247 | `stale-docstring` (diff mode) | Message: `f"{kind} '{symbol.name}' {classification} changed..."` |
+| 439-443 | `stale-drift` | Message: `f"{kind} '{sym.name}' code modified..."` |
+| 467-468 | `stale-age` | Message: `f"{kind} '{sym.name}' docstring untouched..."` |
+
+**Coverage (`coverage.py`) — 1 `symbol=` site:**
+
+| Lines | Notes |
+|-------|-------|
+| 104-111 | Hardcoded `symbol="<module>"` — replace with `module_display_name(representative)` |
+
+### Test Assertion Map
+
+| Category | File | Count | Action |
+|----------|------|-------|--------|
+| STAYS | `test_ast_utils.py` (lines 160, 185) | 2 | No change — AST layer |
+| STAYS | `test_freshness.py` (line 513) | 1 | No change — Symbol fixture |
+| UPDATE | `test_enrichment.py` (symbol assertions) | 6 | Change expected from `"<module>"` to `"regular"` or `"__init__"` |
+| UPDATE | `test_enrichment.py` (message assertions) | 5 | Change `"Module '<module>'"` to `"Module 'regular'"` etc. |
+| UPDATE | `test_presence.py` (symbol filters) | 6 | Change filter from `f.symbol == "<module>"` to derived name |
+| UPDATE | `test_coverage.py` (symbol assertions) | 2 | Change expected to derived name |
+| UPDATE | `test_cli.py` (Finding fixtures + assertions) | 4 | Change `symbol="<module>"` to derived name |
+| ADD | `test_freshness.py` | 1 | New test: module-level freshness finding |
+| **Total** | | **27** | 3 stays, 23 updates, 1 new + generic-rule module tests |
+
+### Files to Reference
+
+| File | Purpose |
+| ---- | ------- |
+| `src/docvet/ast_utils.py` | Home for new `module_display_name()` helper, alongside `Symbol` dataclass |
+| `src/docvet/checks/enrichment.py` | 8 `symbol=` + 8 `message=` sites (3 module-branched + 5 generic) |
+| `src/docvet/checks/presence.py` | 1 `symbol=` + 1 `message=` site (line 144-157) |
+| `src/docvet/checks/freshness.py` | 1 `symbol=` in `_build_finding` (line 80) + 3 caller messages (lines 245, 440, 467) |
+| `src/docvet/checks/coverage.py` | 1 hardcoded `symbol="<module>"` (line 107) |
+| `src/docvet/checks/griffe_compat.py` | Uses `obj.name` from griffe — already correct, no changes |
+| `src/docvet/checks/_finding.py` | Finding dataclass — no changes needed |
+
+### Technical Decisions
+
+- **Helper location**: `ast_utils.py` — it's the "symbol identity" module. The function extends that identity to file-path-derived names. All four check modules already import from `ast_utils`.
+- **Public function**: `module_display_name` (no underscore) since it's consumed cross-module.
+- **AST layer unchanged**: `Symbol.name` stays `"<module>"` at construction. The display name conversion happens at the check layer where `file_path` is available.
+- **Conversion logic**: Normalize backslashes → find source root marker via `rfind("/src/")` or `rfind("/lib/")` for absolute paths, fall back to `startswith("src/")` / `startswith("lib/")` for relative paths → drop `.py` extension → replace `/` with `.` → collapse trailing `.__init__` to package name. Guard: return `"<module>"` on empty string input.
+- **Generic callsite pattern**: For sites that handle all symbol kinds, use `display_name = module_display_name(file_path) if symbol.kind == "module" else symbol.name` to avoid changing non-module behavior.
+- **Freshness pattern**: Fix `symbol=` inside `_build_finding` (single point), fix messages at each of the 3 caller sites.
+- **Coverage pattern**: Use `dir_rel.replace("/", ".")` for the `symbol` field — coverage findings are directory-level (missing `__init__.py`), not module-level. `dir_rel` is already computed (e.g., `"pkg/sub"` → `"pkg.sub"`). Semantically correct: the symbol represents the package that's broken, not a specific file.
+
+## Implementation Plan
+
+### Tasks
+
+- [x] Task 1: Add `module_display_name()` helper to `ast_utils.py`
+  - File: `src/docvet/ast_utils.py`
+  - Action: Add a public function after the `get_documented_symbols()` function. Logic: (1) return `"<module>"` if input is empty string, (2) normalize backslashes to forward slashes, (3) find source root marker via `rfind("/src/")` or `rfind("/lib/")` for absolute paths — strip everything up to and including the marker; fall back to `startswith("src/")` / `startswith("lib/")` for relative paths, (4) drop `.py` extension, (5) replace `/` with `.`, (6) collapse trailing `.__init__` to package name. Add Google-style docstring with Args, Returns, Examples.
+  - Notes: Public (no underscore) — consumed by enrichment, presence, freshness, coverage. Backslash normalization is needed because `cli.py` passes `str(file_path)` which uses OS-native separators on Windows. `discover_files()` returns **absolute** paths (e.g., `/home/user/project/src/pkg/mod.py`) so `rfind` is critical — a simple `startswith("src/")` would never match. No new imports required — pure string manipulation.
+
+- [x] Task 2: Add unit tests for `module_display_name()`
+  - File: `tests/unit/test_ast_utils.py`
+  - Action: Add a new test class `TestModuleDisplayName` with edge-case tests:
+    - `"src/pkg/mod.py"` -> `"pkg.mod"` (relative with src/)
+    - `"pkg/mod.py"` -> `"pkg.mod"` (no src/ prefix)
+    - `"mod.py"` -> `"mod"` (flat script)
+    - `"src/pkg/__init__.py"` -> `"pkg"` (init collapse)
+    - `"__init__.py"` -> `"__init__"` (bare init, no parent)
+    - `"lib/pkg/mod.py"` -> `"pkg.mod"` (lib prefix)
+    - `"src/a/b/c.py"` -> `"a.b.c"` (deep nesting)
+    - `"src/pkg/sub/__init__.py"` -> `"pkg.sub"` (nested init)
+    - `"src\\pkg\\mod.py"` -> `"pkg.mod"` (Windows backslash path)
+    - `"/home/user/project/src/pkg/mod.py"` -> `"pkg.mod"` (absolute path with /src/)
+    - `"/opt/lib/pkg/mod.py"` -> `"pkg.mod"` (absolute path with /lib/)
+    - `""` -> `"<module>"` (empty string guard)
+    - `"Makefile"` -> `"Makefile"` (extensionless file, no .py)
+  - Notes: Run tests after this task to confirm helper works before touching check modules.
+
+- [x] Task 3: Update enrichment module-branched callsites
+  - File: `src/docvet/checks/enrichment.py`
+  - Action: At the 3 module-branched sites (lines ~929, ~1066, ~1162), replace `symbol.name` with `module_display_name(file_path)` in both `symbol=` and `message=` fields. Add `from docvet.ast_utils import module_display_name` to imports.
+  - Notes: These sites are already guarded by `symbol.kind == "module"`, so no conditional needed.
+
+- [x] Task 4: Update enrichment generic callsites
+  - File: `src/docvet/checks/enrichment.py`
+  - Action: At the 5 generic sites (lines ~1188, ~1278, ~1292, ~1345, ~1361), replace `symbol.name` with a conditional: `module_display_name(file_path) if symbol.kind == "module" else symbol.name` for both `symbol=` and `message=` fields.
+  - Notes: Compute `display_name` once per Finding construction to avoid repeating the conditional. Non-module behavior must remain unchanged.
+
+- [x] Task 5: Update enrichment test assertions and add generic-rule module tests
+  - File: `tests/unit/checks/test_enrichment.py`
+  - Action: Update 11 assertions (6 symbol + 5 message) that reference `"<module>"`. Tests passing `file_path="regular.py"` expect `"regular"`. Tests passing `file_path="__init__.py"` expect `"__init__"`. Additionally, add new tests that exercise module-kind symbols through generic rules (e.g., `prefer-fenced-code-blocks`, `missing-cross-references` Branch B) to verify the conditional `module_display_name(file_path) if symbol.kind == "module" else symbol.name` produces the correct display name for module kinds in generic paths.
+  - Notes: Do NOT change tests in `test_ast_utils.py` — those validate Symbol construction which is unchanged.
+
+- [x] Task 6: Update presence check
+  - File: `src/docvet/checks/presence.py`
+  - Action: At line ~153, replace `symbol=symbol.name` with `symbol=module_display_name(file_path)` when `symbol.kind == "module"`. At line ~145, update message from `"Module has no docstring"` to `f"Module '{module_display_name(file_path)}' has no docstring"`. Add import.
+  - Notes: Non-module symbols (function, class, method) continue using `symbol.name` unchanged.
+
+- [x] Task 7: Update presence test assertions
+  - File: `tests/unit/checks/test_presence.py`
+  - Action: Update 6 symbol filter assertions from `f.symbol == "<module>"` to the derived name based on each test's `file_path`: `"mod"` (for `"mod.py"`), `"imports"` (for `"imports.py"`), `"app"` (for `"app.py"`), `"script"` (for `"script.py"`), `"legacy"` (for `"legacy.py"`).
+  - Notes: Also update any message assertions if presence message now includes the module name.
+
+- [x] Task 8: Update freshness check
+  - File: `src/docvet/checks/freshness.py`
+  - Action: In `_build_finding` (line ~80), replace `symbol=symbol.name` with conditional: `symbol=module_display_name(file_path) if symbol.kind == "module" else symbol.name`. At lines ~245, ~440, ~467, replace `symbol.name`/`sym.name` with conditional display name in message construction. Add import.
+  - Notes: `_build_finding` receives both `file_path` and `symbol` — all data available.
+
+- [x] Task 9: Add freshness module-level finding test
+  - File: `tests/unit/checks/test_freshness.py`
+  - Action: Add a new test that exercises a module-level freshness finding (e.g., module body changed but docstring not updated) and asserts the `symbol` field uses the display name and the message says `"Module 'test' body changed..."` instead of `"Module '<module>' body changed..."`.
+  - Notes: Existing Symbol fixture at line 513 stays unchanged (it tests `_classify_changed_lines`, not Finding construction).
+
+- [x] Task 10: Update coverage check
+  - File: `src/docvet/checks/coverage.py`
+  - Action: At line ~107, replace `symbol="<module>"` with `symbol=dir_rel.replace("/", ".")`. The `dir_rel` variable is already computed at line ~98.
+  - Notes: No import needed — pure string operation. Coverage findings are directory-level, so `dir_rel` (e.g., `"pkg.sub"`) is semantically correct.
+
+- [x] Task 11: Update coverage test assertions
+  - File: `tests/unit/checks/test_coverage.py`
+  - Action: Update 2 assertions from `symbol == "<module>"` to the dotted directory name (e.g., `"pkg/sub"` -> `"pkg.sub"`, `"pkg"` -> `"pkg"`).
+
+- [x] Task 12: Update CLI test Finding fixtures
+  - File: `tests/unit/test_cli.py`
+  - Action: Update 3 Finding fixture constructions and 1 assertion from `symbol="<module>"` to the dotted directory name matching what coverage now produces (e.g., `"pkg.sub"` for `dir_rel="pkg/sub"`, `"pkg"` for `dir_rel="pkg"`).
+
+- [x] Task 13: Run full test suite and verify
+  - Action: Run `uv run pytest` to confirm all tests pass. Run `uv run ruff check .` and `uv run ruff format --check .` to confirm lint/format compliance.
+  - Notes: If any tests fail, fix assertion values — the helper conversion table in Task 2 is the source of truth.
+
+### Acceptance Criteria
+
+- [x] AC 1: Given a file path `"src/gepa_adk/config.py"`, when `module_display_name()` is called, then it returns `"gepa_adk.config"`.
+- [x] AC 2: Given a file path `"src/pkg/__init__.py"`, when `module_display_name()` is called, then it returns `"pkg"` (trailing `.__init__` collapsed).
+- [x] AC 3: Given a file path `"mod.py"` (flat script, no prefix), when `module_display_name()` is called, then it returns `"mod"`.
+- [x] AC 4: Given a file path `"__init__.py"` (bare init), when `module_display_name()` is called, then it returns `"__init__"` (no parent to collapse into).
+- [x] AC 5: Given a module-level enrichment finding for file `"src/pkg/config.py"`, when the finding is constructed, then `symbol == "pkg.config"` and message contains `"Module 'pkg.config'"` (not `"<module>"`).
+- [x] AC 6: Given a module-level enrichment finding via a generic rule (e.g., `prefer-fenced-code-blocks`) for file `"src/pkg/config.py"`, when the finding is constructed, then `symbol` and message use the display name for module kind, and non-module symbols are unchanged.
+- [x] AC 7: Given a module without a docstring checked by presence for file `"app.py"`, when the finding is constructed, then `symbol == "app"` and message is `"Module 'app' has no docstring"`.
+- [x] AC 8: Given a module-level freshness finding (body changed, docstring not updated) for file `"src/pkg/utils.py"`, when the finding is constructed, then `symbol` uses the display name and message contains `"Module 'pkg.utils'"` and does not contain `"<module>"`.
+- [x] AC 9: Given a coverage finding for directory `"pkg/sub"` lacking `__init__.py`, when the finding is constructed, then `symbol == "pkg.sub"` (dotted directory name, not `"<module>"`).
+- [x] AC 10: Given a function-level finding via a generic enrichment rule (e.g., `prefer-fenced-code-blocks`) for file `"src/pkg/config.py"`, when the finding is constructed, then `symbol` uses the function name (e.g., `"run_check"`), NOT the module display name — the conditional only applies to module-kind symbols.
+- [x] AC 11: Given an absolute file path `/home/user/project/src/pkg/mod.py`, when `module_display_name()` is called, then it returns `"pkg.mod"` (rfind locates `/src/` marker regardless of leading path components).
+- [x] AC 12: Given the full test suite, when `uv run pytest` is executed, then all tests pass (including updated assertions and new helper tests).
+- [x] AC 13: Given the `Symbol` dataclass in `ast_utils.py`, when a module symbol is created by `get_documented_symbols()`, then `name` is still `"<module>"` (AST layer unchanged).
+
+## Additional Context
+
+### Dependencies
+
+None — no new runtime or dev dependencies. Pure string manipulation using stdlib only.
+
+### Testing Strategy
+
+- **Helper unit tests** (Task 2): Dedicated `TestModuleDisplayName` class in `test_ast_utils.py` covering 13 edge cases (AC 1-4, AC 11). Run after Task 1 to confirm helper before touching check modules.
+- **Enrichment assertion updates** (Task 5): 11 assertions across existing tests. Expected values derived from `file_path` each test passes (`"regular.py"` -> `"regular"`, `"__init__.py"` -> `"__init__"`).
+- **Presence assertion updates** (Task 7): 6 filter assertions. Each test uses a different `file_path` (`"mod.py"`, `"app.py"`, `"imports.py"`, `"script.py"`, `"legacy.py"`).
+- **Coverage assertion updates** (Task 11): 2 assertions. Expected values derived from `dir_rel` (`"pkg/sub"` -> `"pkg.sub"`, `"pkg"` -> `"pkg"`).
+- **CLI fixture updates** (Task 12): 4 Finding constructions/assertions. Values must match what coverage now produces.
+- **New freshness test** (Task 9): Module-level finding validates `symbol` and `message` use display name. No existing test covers this path.
+- **`test_ast_utils.py` unchanged**: Symbol construction tests (`name == "<module>"`) remain — they validate AST-layer behavior (AC 13).
+- **Full suite gate** (Task 13): `uv run pytest` must pass all tests.
+
+### Notes
+
+- Discovered via real-world usage of `docvet@v1` GitHub Action in `gepa-adk` CI (run 22805146741)
+- Party mode consensus: team unanimously agreed on dotted-path approach over filename-only or raw-path options
+- Coverage uses `dir_rel.replace("/", ".")` instead of `module_display_name()` — semantically correct for directory-level findings
+- This is a patch-level fix (`fix(checks): replace <module> sentinel with display names in findings`)
+- Risk: low — pure display change, no behavioral or config impact. All changes are to `symbol` and `message` string values in Finding records.
+- **Presence message format change**: The presence module's message changes from `"Module has no docstring"` to `"Module '{display_name}' has no docstring"`. This is a message-text-only change — no behavioral impact — but consumers parsing exact message strings should be aware.

--- a/_bmad-output/planning-artifacts/epics-multi-style-enrichment.md
+++ b/_bmad-output/planning-artifacts/epics-multi-style-enrichment.md
@@ -1,0 +1,631 @@
+---
+stepsCompleted:
+  - 'step-01-validate-prerequisites'
+  - 'step-02-design-epics'
+  - 'step-03-create-stories'
+  - 'step-04-final-validation'
+inputDocuments:
+  - 'gh-issue-320'
+  - 'gh-issue-321'
+  - 'gh-issue-322'
+  - 'gh-issue-323'
+  - 'gh-issue-324'
+  - 'gh-issue-325'
+  - 'gh-issue-326'
+  - 'gh-issue-327'
+  - 'gh-issue-328'
+  - 'gh-issue-329'
+  - '_bmad-output/planning-artifacts/architecture.md'
+  - '_bmad-output/planning-artifacts/prd.md'
+workflowType: 'epics'
+projectName: 'docvet'
+featureScope: 'multi-style-enrichment-expansion'
+---
+
+# docvet - Epic Breakdown: Multi-Style Support & Enrichment Expansion
+
+## Overview
+
+This document provides the epic and story breakdown for docvet's enrichment expansion wave, sourced from 10 GitHub issues (#320-#329) validated by running docvet against boto3 (the most downloaded PyPI package). Covers multi-style docstring support (Sphinx/RST, NumPy), 8 new enrichment rules, and bidirectional verification — filling the darglint vacuum and unlocking adoption for the majority of the Python ecosystem.
+
+## Requirements Inventory
+
+### Functional Requirements
+
+FR1: (#320) A `docstring-style` config key shall accept `"google"` (default) and `"sphinx"` values in `[tool.docvet]`.
+
+FR2: (#320) When `docstring-style = "sphinx"`, section detection shall recognize RST equivalents: `:param:`/`:type:` as Args, `:returns:`/`:rtype:` as Returns, `:raises:` as Raises, `:ivar:`/`:cvar:` as Attributes, `.. seealso::` or inline `:py:*:` as See Also, `>>>`/`::`/`.. code-block::` as Examples.
+
+FR3: (#320) When `docstring-style = "sphinx"`, rules with no RST equivalent (require\_yields, require\_receives, require\_warns, require\_other\_parameters) shall be auto-disabled.
+
+FR4: (#320) When `docstring-style = "sphinx"`, `prefer-fenced-code-blocks` shall be auto-disabled (RST code patterns are correct).
+
+FR5: (#320) When `docstring-style = "sphinx"`, `missing-cross-references` shall accept Sphinx roles (`:py:class:`, `:py:meth:`, etc.) anywhere in the docstring body.
+
+FR6: (#320) When `docstring-style = "sphinx"`, the griffe check shall be auto-skipped (Google parser incompatible).
+
+FR7: (#321) `missing-returns` rule shall detect functions with `return <expr>` statements but no `Returns:` section in their docstring.
+
+FR8: (#321) `missing-returns` shall exclude bare `return`/`return None`, `@property` methods, `__init__`, and all dunder methods.
+
+FR9: (#322) `missing-param-in-docstring` rule shall detect function signature parameters not documented in the `Args:` section.
+
+FR10: (#322) `extra-param-in-docstring` rule shall detect `Args:` entries that do not correspond to a parameter in the function signature.
+
+FR11: (#322) Param agreement checks shall always exclude `self`/`cls` and configurably exclude `*args`/`**kwargs` (default: exclude).
+
+FR12: (#323) `missing-deprecation` rule shall detect functions with deprecation patterns in code but no deprecation notice in their docstring.
+
+FR13: (#323) Deprecation detection shall cover `warnings.warn(..., DeprecationWarning)`, `PendingDeprecationWarning`, `FutureWarning`, and `@deprecated` decorator.
+
+FR14: (#324) `extra-raises-in-docstring` rule shall detect exception names documented in `Raises:` that do not appear in `raise` statements in the function body.
+
+FR15: (#324) `extra-yields-in-docstring` rule shall detect `Yields:` sections on functions with no `yield`/`yield from` statements.
+
+FR16: (#324) `extra-returns-in-docstring` rule shall detect `Returns:` sections on functions with no `return <expr>` statements.
+
+FR17: (#325) `trivial-docstring` rule shall detect docstrings whose summary line is a subset restatement of the symbol name with no additional information.
+
+FR18: (#325) Trivial detection shall decompose `snake_case` and `CamelCase` into word sets, filter stop words, and compare summary words against name words.
+
+FR19: (#326) `missing-return-type` rule shall detect functions with a `Returns:` section where the entry has no type AND the function has no `->` return annotation.
+
+FR20: (#326) Either a typed `Returns:` entry OR a return annotation shall satisfy the check (either is sufficient).
+
+FR21: (#327) Section parser shall recognize `Notes`, `References`, `Warnings`, `Extended Summary`, and `Methods` as valid section headers.
+
+FR22: (#327) Section parser shall detect NumPy underline format (`---` delimited sections) alongside Google colon format.
+
+FR23: (#328) `undocumented-init-params` rule shall detect classes with parameterized `__init__` but no `Args:`/`Parameters:` section in either the class docstring or `__init__` docstring.
+
+FR24: (#328) `Args:` in either the class docstring or `__init__` docstring shall satisfy the check.
+
+FR25: (#329) `overload-has-docstring` rule shall detect `@overload`-decorated functions (from `typing` or `typing_extensions`) that have docstrings.
+
+### NonFunctional Requirements
+
+NFR1: (#320) No RST parser dependency — Sphinx detection shall use pattern matching only, keeping docvet dependency-free.
+
+NFR2: (all) No new runtime dependencies for any issue — stdlib + typer only.
+
+NFR3: (all) All new `_check_*` functions shall follow the established uniform signature: `(symbol, sections, node_index, config, file_path) -> Finding | None`.
+
+NFR4: (all) All new rules shall wire into the `_RULE_DISPATCH` table with zero dispatch machinery changes.
+
+NFR5: (#320) Style auto-disable logic shall preserve user config overrides — explicit settings beat auto-disable defaults.
+
+NFR6: (#327) Section recognition additions shall be purely additive — no breaking changes to existing section parsing behavior.
+
+NFR7: (all) All new rules shall follow existing test patterns: one file per module, fixtures in `tests/fixtures/`, `@pytest.mark.unit` markers.
+
+NFR8: (#320) Sphinx/RST style support must land before enrichment rules that reference style dispatch in their "Sphinx/RST interaction" sections.
+
+NFR9: (#324) Reverse checks shall default to `recommended` category due to higher false positive risk from implicit raises/returns.
+
+NFR10: (#326) `missing-return-type` shall default to `False` (opt-in) as a stricter check that may not suit all projects.
+
+### Additional Requirements
+
+- From architecture: `_RULE_DISPATCH` table-driven dispatch (from Epic 12 CC refactor) absorbs new rules with zero architecture change. Each `_check_*` function is independently testable.
+- From architecture: Config gating lives in the orchestrator, not inside `_check_*` functions. Boolean toggles are checked before dispatch; list toggles are checked inside the function.
+- From architecture: `_parse_sections()` is the extension point for style-aware section detection. `_SECTION_HEADERS` frozenset is the single place to add recognized sections.
+- From architecture: `_extract_section_content()` is the foundation for Args entry parsing (#322) and Raises entry parsing (#324).
+- From architecture: Scope-aware AST walking (stop at nested `def`/`class`) is the established pattern for all body-inspection rules.
+- From architecture: `node_index` line-based lookup provides O(1) access per rule per symbol.
+- From party-mode consensus (2026-03-07): #320 is the architectural foundation — style dispatch mechanism that all other issues reference. Ship first.
+- From party-mode consensus (2026-03-07): Remaining enrichment issues (#322-#326, #328) can be batched into a follow-up epic after the foundation lands.
+- From boto3 validation: 678 Sphinx/RST markers across 34 files, 0 Google-style markers. Sphinx/RST is the dominant style for Django, Flask, SQLAlchemy, requests, boto3/botocore, CPython stdlib, Celery.
+- Sphinx section patterns are parallel to Google patterns — same internal section names, different regex. Implementation adds a `_SPHINX_SECTION_MAP` alongside existing `_SECTION_PATTERN`.
+- NumPy section recognition (Phase 1) is additive only — no enforcement rules, just preventing content bleed in section-boundary parsing.
+- `overload-has-docstring` (#329) may live in presence layer rather than enrichment — placement is a design decision.
+- From party-mode consensus (2026-03-07 story review): Every rule story must include a docs-page AC — rule reference page in `docs/rules/` registered in `docs/rules.yml`.
+- From party-mode consensus (2026-03-07 story review): Story 35.4 (trivial-docstring) must handle CamelCase acronym edge case — consecutive uppercase treated as one word until lowercase transition (e.g., `HTTPSConnection` → `{https, connection}`).
+- From party-mode consensus (2026-03-07 story review): Epic 35 implementation order should prioritize unique rules (35.2, 35.4, 35.6) before pydoclint-overlap rules (35.1, 35.3, 35.5). Sprint priority decided by SM.
+- From party-mode consensus (2026-03-07 story review): Story 35.3 (reverse checks, 3 rules in 1 M story) may be split into 3 S stories at sprint time if velocity requires.
+- From competitor research (2026-03-07): pydoclint v0.8.3 is the primary active competitor — supports Google/Sphinx/NumPy with 21 DOC rules covering param/return/yield/raise agreement. Ruff has DOC201/202/402/403/501/502 in preview (unstable). Neither tool covers freshness, rendering, or discoverability — docvet layers 4-6 are uncontested.
+
+### FR Coverage Map
+
+| FR | Epic | Story | Description |
+|----|------|-------|-------------|
+| FR1 | 34 | 34.1 | `docstring-style` config key |
+| FR2 | 34 | 34.1 | Sphinx RST section pattern detection |
+| FR3 | 34 | 34.1 | Auto-disable inapplicable rules in sphinx mode |
+| FR4 | 34 | 34.1 | Auto-disable prefer-fenced-code-blocks in sphinx mode |
+| FR5 | 34 | 34.1 | Sphinx cross-reference roles in body |
+| FR6 | 34 | 34.1 | Auto-skip griffe in sphinx mode |
+| FR7 | 34 | 34.2 | missing-returns detection |
+| FR8 | 34 | 34.2 | missing-returns exclusions |
+| FR9 | 35 | 35.1 | missing-param-in-docstring detection |
+| FR10 | 35 | 35.1 | extra-param-in-docstring detection |
+| FR11 | 35 | 35.1 | Param agreement self/cls/*args/**kwargs handling |
+| FR12 | 35 | 35.2 | missing-deprecation detection |
+| FR13 | 35 | 35.2 | Deprecation pattern coverage |
+| FR14 | 35 | 35.3 | extra-raises-in-docstring detection |
+| FR15 | 35 | 35.3 | extra-yields-in-docstring detection |
+| FR16 | 35 | 35.3 | extra-returns-in-docstring detection |
+| FR17 | 35 | 35.4 | trivial-docstring detection |
+| FR18 | 35 | 35.4 | Word decomposition and stop word filtering |
+| FR19 | 35 | 35.5 | missing-return-type detection |
+| FR20 | 35 | 35.5 | Type in docstring OR annotation satisfies check |
+| FR21 | 34 | 34.3 | NumPy section header recognition |
+| FR22 | 34 | 34.3 | NumPy underline format detection |
+| FR23 | 35 | 35.6 | undocumented-init-params detection |
+| FR24 | 35 | 35.6 | Class or __init__ docstring satisfies check |
+| FR25 | 34 | 34.4 | overload-has-docstring detection |
+
+## Epic List
+
+### Epic 34: Multi-Style Support & Foundation Rules
+
+Developers using Sphinx/RST or NumPy-style docstrings get meaningful enrichment checks without false positives, and three quick-win rules ship alongside the style infrastructure — unlocking docvet adoption for the majority of the Python ecosystem.
+
+**FRs covered:** FR1-FR8, FR21-FR22, FR25
+**Stories:** 4
+
+- **Story 34.1:** Sphinx/RST docstring style support (FR1-FR6 + NFR1, NFR5) — L
+- **Story 34.2:** `missing-returns` enrichment rule (FR7-FR8 + NFR3, NFR4) — S
+- **Story 34.3:** NumPy-style section recognition Phase 1 (FR21-FR22 + NFR6) — XS
+- **Story 34.4:** `overload-has-docstring` check (FR25 + NFR3) — XS
+
+### Epic 35: Enrichment Depth — Correctness & Completeness Rules
+
+Developers get bidirectional docstring verification — both "code has behavior, docstring should document it" AND "docstring claims behavior, code should exhibit it" — plus parameter agreement, deprecation notices, trivial docstring detection, return type completeness, and init param documentation. Fills the darglint vacuum completely.
+
+**FRs covered:** FR9-FR20, FR23-FR24
+**Stories:** 6
+
+- **Story 35.1:** Docstring-parameter agreement checks (FR9-FR11 + NFR3, NFR4) — M
+- **Story 35.2:** `missing-deprecation` enrichment rule (FR12-FR13 + NFR3, NFR4) — S
+- **Story 35.3:** Reverse enrichment checks (FR14-FR16 + NFR3, NFR4, NFR9) — M
+- **Story 35.4:** `trivial-docstring` enrichment rule (FR17-FR18 + NFR3, NFR4) — S
+- **Story 35.5:** `missing-return-type` enrichment rule (FR19-FR20 + NFR3, NFR4, NFR10) — S
+- **Story 35.6:** `undocumented-init-params` enrichment rule (FR23-FR24 + NFR3, NFR4) — S
+
+---
+
+## Epic 34: Multi-Style Support & Foundation Rules
+
+### Story 34.1: Sphinx/RST docstring style support
+
+As a developer maintaining a Sphinx/RST-style codebase,
+I want docvet to recognize RST section patterns and auto-disable incompatible rules,
+So that I get meaningful enrichment findings without false positives.
+
+**Acceptance Criteria:**
+
+**Given** a pyproject.toml with `docstring-style = "sphinx"` under `[tool.docvet]`
+**When** docvet loads the configuration
+**Then** the `docstring_style` field is set to `"sphinx"` and all style-aware behavior switches to RST patterns
+
+**Given** `docstring-style = "sphinx"` is set
+**When** enrichment parses a docstring containing `:param name:`, `:type name:`, `:returns:`, `:rtype:`, `:raises ExcType:`, `:ivar name:`, `:cvar name:`, `.. seealso::`, or `>>>` / `::` / `.. code-block::`
+**Then** each RST pattern is mapped to its Google-equivalent internal section name (Args, Returns, Raises, Attributes, See Also, Examples)
+
+**Given** `docstring-style = "sphinx"` is set
+**When** enrichment evaluates rules that have no RST equivalent (`require-yields`, `require-receives`, `require-warns`, `require-other-parameters`)
+**Then** those rules are auto-disabled and produce no findings
+
+**Given** `docstring-style = "sphinx"` is set
+**When** enrichment evaluates `prefer-fenced-code-blocks`
+**Then** the rule is auto-disabled (RST `::` and `>>>` patterns are correct in Sphinx mode)
+
+**Given** `docstring-style = "sphinx"` is set
+**When** enrichment evaluates `missing-cross-references`
+**Then** Sphinx roles (`:py:class:`, `:py:meth:`, `:py:func:`, etc.) anywhere in the docstring body satisfy the cross-reference check
+
+**Given** `docstring-style = "sphinx"` is set
+**When** the CLI runs `docvet check` or `docvet griffe`
+**Then** the griffe compatibility check is auto-skipped (Google parser is incompatible with RST)
+
+**Given** `docstring-style = "sphinx"` is set AND the user has explicitly set `require-yields = true` in their config
+**When** enrichment evaluates the yields rule
+**Then** the explicit user setting overrides auto-disable and the rule runs (NFR5: explicit settings beat auto-disable defaults)
+
+**Given** `docstring-style` is omitted from config
+**When** docvet loads the configuration
+**Then** the default value is `"google"` and all existing behavior is unchanged
+
+**Given** `docstring-style` is set to an invalid value (e.g., `"numpy"`, `"plain"`)
+**When** docvet loads the configuration
+**Then** a clear validation error is raised listing valid options
+
+**Given** a Sphinx-style docstring with `:param name:` entries
+**When** `_parse_sections()` runs in sphinx mode
+**Then** section detection uses pattern matching only — no RST parser dependency (NFR1)
+
+**Given** a Google-style docstring with `Args:`, `Returns:`, `Raises:` headers
+**When** `_parse_sections()` runs in google mode (default)
+**Then** behavior is identical to the current implementation — zero regression
+
+**Given** `docstring-style = "sphinx"` is set
+**When** running `docvet check --all` against boto3
+**Then** false positives from RST-style docstrings are eliminated (the 678 RST markers across 34 files produce section matches, not missing-section findings)
+
+**Given** `docstring-style` is a new top-level config key under `[tool.docvet]`
+**When** the story is marked done
+**Then** the configuration reference page in `docs/` documents the key with valid values (`"google"`, `"sphinx"`), default (`"google"`), and behavior summary including auto-disable rules
+
+### Story 34.2: `missing-returns` enrichment rule
+
+As a developer,
+I want docvet to flag functions that return values but have no Returns section,
+So that callers know what the function returns by reading its docstring.
+
+**Acceptance Criteria:**
+
+**Given** a function with `return <expr>` statements and a docstring with no `Returns:` section
+**When** enrichment runs
+**Then** a finding is emitted: `missing-returns` with message identifying the function name
+
+**Given** a function with only bare `return` or `return None` statements
+**When** enrichment runs
+**Then** no `missing-returns` finding is produced (control flow returns are not meaningful)
+
+**Given** a function with a mix of `return value` and bare `return` statements
+**When** enrichment runs
+**Then** a `missing-returns` finding IS produced (at least one meaningful return exists)
+
+**Given** a `@property` method, `__init__`, or any dunder method (`__repr__`, `__len__`, `__bool__`, etc.)
+**When** enrichment runs
+**Then** no `missing-returns` finding is produced (skip set applies)
+
+**Given** a function with `return <expr>` inside a nested function or class
+**When** enrichment runs on the outer function
+**Then** no `missing-returns` finding is produced for the outer function (scope-aware AST walk stops at nested `def`/`class`)
+
+**Given** a function with a `Returns:` section already present
+**When** enrichment runs
+**Then** no `missing-returns` finding is produced
+
+**Given** `require-returns = false` in `[tool.docvet.enrichment]`
+**When** enrichment runs
+**Then** the `missing-returns` rule is skipped entirely
+
+**Given** `require-returns = true` (the default)
+**When** the rule is dispatched
+**Then** `_check_missing_returns` follows the uniform signature `(symbol, sections, node_index, config, file_path) -> Finding | None` and is wired into `_RULE_DISPATCH` with zero dispatch changes
+
+**Given** a function with no docstring
+**When** enrichment runs
+**Then** no `missing-returns` finding is produced (enrichment only runs on functions that have docstrings)
+
+**Given** the `missing-returns` rule is implemented and tested
+**When** the story is marked done
+**Then** a rule reference page exists in `docs/rules/` and is registered in `docs/rules.yml` following the existing pattern (macros scaffold in `docs/main.py`)
+
+### Story 34.3: NumPy-style section recognition Phase 1
+
+As a developer maintaining a NumPy-style codebase,
+I want docvet's section parser to recognize NumPy sections and underline format,
+So that section-boundary parsing doesn't bleed content across sections.
+
+**Acceptance Criteria:**
+
+**Given** a docstring with `Notes`, `References`, `Warnings`, `Extended Summary`, or `Methods` as section headers
+**When** `_parse_sections()` runs
+**Then** these headers are recognized as valid section boundaries (added to `_SECTION_HEADERS` frozenset)
+
+**Given** a docstring with NumPy underline format (e.g., `Parameters\n----------`)
+**When** `_parse_sections()` runs
+**Then** the underline format is detected alongside Google colon format as a section delimiter
+
+**Given** a docstring with a `Notes` section followed by a `Returns` section
+**When** `_extract_section_content()` extracts `Returns` content
+**Then** `Notes` content does not bleed into the `Returns` section (correct boundary detection)
+
+**Given** existing Google-style docstrings with `Args:`, `Returns:`, `Raises:` headers
+**When** `_parse_sections()` runs after the NumPy additions
+**Then** all existing section detection behavior is identical — zero regression (NFR6)
+
+**Given** a NumPy-style `Notes` section exists in a docstring
+**When** enrichment rules run
+**Then** no enforcement rules fire for `Notes` — recognition is additive only, no new required-section rules
+
+**Given** the `_SECTION_HEADERS` frozenset after this story
+**When** inspecting the codebase
+**Then** exactly 5 new entries are added: `Notes`, `References`, `Warnings`, `Extended Summary`, `Methods`
+
+### Story 34.4: `overload-has-docstring` check
+
+As a developer,
+I want docvet to flag `@overload`-decorated functions that have docstrings,
+So that documentation lives only on the implementation function where `help()` and doc generators expect it.
+
+**Acceptance Criteria:**
+
+**Given** a function decorated with `@overload` (from `typing` or `typing_extensions`) that has a docstring
+**When** the check runs
+**Then** a finding is emitted: `overload-has-docstring` with message identifying the function name
+
+**Given** a function decorated with `@typing.overload` (attribute access form) that has a docstring
+**When** the check runs
+**Then** a finding is emitted (both `@overload` name form and `@typing.overload` attribute form are detected)
+
+**Given** an `@overload`-decorated function with no docstring
+**When** the check runs
+**Then** no finding is produced
+
+**Given** the implementation function (no `@overload` decorator) with a docstring
+**When** the check runs
+**Then** no finding is produced (only overloads are flagged)
+
+**Given** `check-overload-docstrings = false` in config
+**When** the check runs
+**Then** the rule is skipped entirely
+
+**Given** the `overload-has-docstring` rule
+**When** inspecting its wiring
+**Then** the rule lives in the presence layer (not enrichment) since it's about whether a docstring should exist, following the `_check_*` uniform signature (NFR3)
+
+**Given** the `overload-has-docstring` rule is implemented and tested
+**When** the story is marked done
+**Then** a rule reference page exists in `docs/rules/` and is registered in `docs/rules.yml` following the existing pattern
+
+---
+
+## Epic 35: Enrichment Depth — Correctness & Completeness Rules
+
+> **Implementation order note (party-mode consensus 2026-03-07):** Stories are numbered for reference, not execution order. Recommended sprint sequencing prioritizes unique rules before pydoclint-overlap rules: 35.2 (missing-deprecation) → 35.4 (trivial-docstring) → 35.6 (undocumented-init-params) → 35.1 (param agreement) → 35.5 (missing-return-type) → 35.3 (reverse checks). SM decides final sprint priority.
+>
+> **Splitting note:** Story 35.3 packs 3 rules into one M story. If velocity wobbles, split into 3 S stories at sprint time — the ACs already separate the three rules cleanly.
+
+### Story 35.1: Docstring-parameter agreement checks
+
+As a developer,
+I want docvet to flag signature parameters missing from `Args:` and `Args:` entries not in the signature,
+So that my docstrings accurately reflect the function's actual interface.
+
+**Acceptance Criteria:**
+
+**Given** a function with an `Args:` section where a signature parameter is not documented
+**When** enrichment runs
+**Then** a `missing-param-in-docstring` finding is emitted naming the undocumented parameter
+
+**Given** a function with an `Args:` section that documents a name not in the signature
+**When** enrichment runs
+**Then** an `extra-param-in-docstring` finding is emitted naming the stale/incorrect entry
+
+**Given** a method with `self` or `cls` as the first parameter
+**When** enrichment runs
+**Then** `self`/`cls` are always excluded from agreement checks (never expected in `Args:`)
+
+**Given** a function with `*args` and `**kwargs` parameters and default config
+**When** enrichment runs
+**Then** `*args`/`**kwargs` are excluded from agreement checks (default: exclude)
+
+**Given** `exclude-args-kwargs = false` in `[tool.docvet.enrichment]`
+**When** enrichment runs on a function with `*args`/`**kwargs` not in `Args:`
+**Then** findings are emitted for the undocumented `*args`/`**kwargs`
+
+**Given** a function with a docstring but no `Args:` section
+**When** enrichment runs
+**Then** no param agreement findings are produced (missing section is a different concern)
+
+**Given** a function with parameters that all appear in `Args:` and vice versa
+**When** enrichment runs
+**Then** zero param agreement findings are produced
+
+**Given** `_parse_args_entries` helper
+**When** it parses an `Args:` section
+**Then** it extracts parameter names using `_extract_section_content()` and returns a `set[str]` of documented names
+
+**Given** `require-param-agreement = false` in config
+**When** enrichment runs
+**Then** both `missing-param-in-docstring` and `extra-param-in-docstring` rules are skipped
+
+**Given** both param agreement rules are implemented and tested
+**When** the story is marked done
+**Then** rule reference pages exist in `docs/rules/` for both `missing-param-in-docstring` and `extra-param-in-docstring`, registered in `docs/rules.yml`
+
+### Story 35.2: `missing-deprecation` enrichment rule
+
+As a developer,
+I want docvet to flag functions with deprecation patterns in code but no deprecation notice in their docstring,
+So that users reading documentation know to migrate away from deprecated APIs.
+
+**Acceptance Criteria:**
+
+**Given** a function body containing `warnings.warn(..., DeprecationWarning)`
+**When** enrichment runs and the docstring does not contain the word "deprecated" (case-insensitive)
+**Then** a `missing-deprecation` finding is emitted
+
+**Given** a function body containing `warnings.warn(..., PendingDeprecationWarning)` or `warnings.warn(..., FutureWarning)`
+**When** enrichment runs and the docstring has no deprecation notice
+**Then** a `missing-deprecation` finding is emitted (all three warning categories are covered)
+
+**Given** a function decorated with `@deprecated` (from `typing_extensions` or `warnings`)
+**When** enrichment runs and the docstring has no deprecation notice
+**Then** a `missing-deprecation` finding is emitted
+
+**Given** a function with a deprecation pattern in code AND the word "deprecated" anywhere in the docstring
+**When** enrichment runs
+**Then** no finding is produced (intentionally loose matching avoids false positives)
+
+**Given** a function with no deprecation patterns in code
+**When** enrichment runs
+**Then** no `missing-deprecation` finding is produced
+
+**Given** a deprecation `warnings.warn(...)` inside a nested function
+**When** enrichment runs on the outer function
+**Then** no finding is produced for the outer function (scope-aware AST walk)
+
+**Given** `require-deprecation-notice = false` in config
+**When** enrichment runs
+**Then** the rule is skipped entirely
+
+**Given** the `missing-deprecation` rule is implemented and tested
+**When** the story is marked done
+**Then** a rule reference page exists in `docs/rules/` and is registered in `docs/rules.yml` following the existing pattern
+
+### Story 35.3: Reverse enrichment checks
+
+As a developer,
+I want docvet to flag docstrings that claim behavior the code doesn't exhibit,
+So that my docstrings don't mislead callers about raises, yields, or returns.
+
+**Acceptance Criteria:**
+
+**Given** a function with a `Raises:` section documenting `ValueError` but no `raise ValueError` in the function body
+**When** enrichment runs
+**Then** an `extra-raises-in-docstring` finding is emitted naming the undocumented exception
+
+**Given** a function with a `Raises:` section documenting exceptions that ALL appear in `raise` statements
+**When** enrichment runs
+**Then** no `extra-raises-in-docstring` findings are produced
+
+**Given** a function with a `Yields:` section but no `yield` or `yield from` statements in the body
+**When** enrichment runs
+**Then** an `extra-yields-in-docstring` finding is emitted
+
+**Given** a function with a `Returns:` section but no `return <expr>` statements in the body (only bare `return` or `return None`)
+**When** enrichment runs
+**Then** an `extra-returns-in-docstring` finding is emitted
+
+**Given** a function with `raise` inside a nested function or class
+**When** enrichment runs on the outer function
+**Then** the nested raise is not counted (scope-aware walk stops at nested `def`/`class`)
+
+**Given** a `Raises:` section entry with an exception raised via re-raise (`raise` with no argument inside `except`)
+**When** enrichment runs
+**Then** the re-raised exception type is not matched (bare `raise` has no explicit type)
+
+**Given** all three reverse rules
+**When** checking their default category
+**Then** findings are categorized as `recommended` (not `required`) due to higher false positive risk from implicit raises/returns (NFR9)
+
+**Given** `require-extra-raises-check = false`, `require-extra-yields-check = false`, or `require-extra-returns-check = false` in config
+**When** enrichment runs
+**Then** the corresponding rule is skipped
+
+**Given** the `_parse_raises_entries` helper
+**When** it parses a `Raises:` section
+**Then** it extracts exception class names from the section using `_extract_section_content()` and returns a `set[str]`
+
+**Given** all three reverse rules are implemented and tested
+**When** the story is marked done
+**Then** rule reference pages exist in `docs/rules/` for `extra-raises-in-docstring`, `extra-yields-in-docstring`, and `extra-returns-in-docstring`, registered in `docs/rules.yml`
+
+### Story 35.4: `trivial-docstring` enrichment rule
+
+As a developer,
+I want docvet to flag docstrings that trivially restate the symbol name,
+So that docstrings add real information value beyond what the name already communicates.
+
+**Acceptance Criteria:**
+
+**Given** a function `get_user` with docstring `"""Get user."""`
+**When** enrichment runs
+**Then** a `trivial-docstring` finding is emitted (summary word set `{get, user}` == name word set `{get, user}`)
+
+**Given** a class `UserManager` with docstring `"""User manager."""`
+**When** enrichment runs
+**Then** a `trivial-docstring` finding is emitted (`CamelCase` decomposed to `{user, manager}`)
+
+**Given** a function `process_data` with docstring `"""Process the data."""`
+**When** enrichment runs
+**Then** a `trivial-docstring` finding is emitted (stop words like "the" are filtered, leaving `{process, data}` ⊆ `{process, data}`)
+
+**Given** a function `get_user` with docstring `"""Fetch a user from the database by their ID."""`
+**When** enrichment runs
+**Then** no `trivial-docstring` finding is produced (summary adds "database", "ID", "fetch" — not a subset)
+
+**Given** a `_STOP_WORDS` frozenset
+**When** word filtering runs
+**Then** common English articles and prepositions (`a`, `an`, `the`, `of`, `for`, `to`, `in`, `is`, `it`, `and`, `or`, `this`, `that`, `with`, `from`, `by`, `on`) are excluded from comparison
+
+**Given** both `snake_case` and `CamelCase` symbol names
+**When** word decomposition runs
+**Then** `snake_case` splits on `_` and `CamelCase` splits on uppercase boundaries, both lowercased
+
+**Given** a CamelCase name with consecutive uppercase letters like `HTTPSConnection` or `HTMLParser`
+**When** word decomposition runs
+**Then** consecutive uppercase letters are treated as one word until a lowercase transition, producing `{https, connection}` and `{html, parser}` respectively (not letter-by-letter splitting)
+
+**Given** `check-trivial-docstrings = false` in config
+**When** enrichment runs
+**Then** the rule is skipped entirely
+
+**Given** the `trivial-docstring` rule is implemented and tested
+**When** the story is marked done
+**Then** a rule reference page exists in `docs/rules/` and is registered in `docs/rules.yml` following the existing pattern
+
+### Story 35.5: `missing-return-type` enrichment rule
+
+As a developer,
+I want docvet to flag functions with a `Returns:` section that has no type when the function also lacks a return annotation,
+So that callers can determine the return type from either the docstring or the signature.
+
+**Acceptance Criteria:**
+
+**Given** a function with a `Returns:` section where the first entry has no type AND the function has no `->` return annotation
+**When** enrichment runs
+**Then** a `missing-return-type` finding is emitted
+
+**Given** a function with a `Returns:` section where the first entry has a type (e.g., `dict: The result.`)
+**When** enrichment runs
+**Then** no finding is produced (typed Returns entry satisfies the check)
+
+**Given** a function with a `Returns:` section with no type BUT the function has a `-> dict` return annotation
+**When** enrichment runs
+**Then** no finding is produced (return annotation satisfies the check — FR20)
+
+**Given** an `__init__`, `__del__`, or property setter method
+**When** enrichment runs
+**Then** no `missing-return-type` finding is produced (excluded by skip set)
+
+**Given** `require-return-type = true` in `[tool.docvet.enrichment]`
+**When** enrichment runs
+**Then** the rule is active
+
+**Given** `require-return-type` is not set in config (default)
+**When** enrichment runs
+**Then** the rule is skipped (defaults to `false` / opt-in per NFR10)
+
+**Given** a `_RETURNS_TYPE_PATTERN` regex
+**When** it examines the first non-empty line under `Returns:`
+**Then** it matches `word:` patterns (type followed by colon) to determine if a type is present
+
+**Given** the `missing-return-type` rule is implemented and tested
+**When** the story is marked done
+**Then** a rule reference page exists in `docs/rules/` and is registered in `docs/rules.yml` following the existing pattern
+
+### Story 35.6: `undocumented-init-params` enrichment rule
+
+As a developer,
+I want docvet to flag classes whose `__init__` takes parameters but neither the class docstring nor `__init__` has an Args section,
+So that constructor parameters are documented somewhere for users.
+
+**Acceptance Criteria:**
+
+**Given** a class with `__init__(self, name, timeout)` and neither the class docstring nor `__init__` docstring has an `Args:` or `Parameters:` section
+**When** enrichment runs
+**Then** an `undocumented-init-params` finding is emitted naming the class and listing the undocumented parameters
+
+**Given** a class with `__init__(self, name)` and the class docstring has an `Args:` section
+**When** enrichment runs
+**Then** no finding is produced (class docstring satisfies the check — FR24)
+
+**Given** a class with `__init__(self, name)` and `__init__` itself has a docstring with an `Args:` section
+**When** enrichment runs
+**Then** no finding is produced (`__init__` docstring satisfies the check — FR24)
+
+**Given** a class with `__init__(self)` (no parameters beyond self)
+**When** enrichment runs
+**Then** no finding is produced (no parameters to document)
+
+**Given** a class with no `__init__` method defined
+**When** enrichment runs
+**Then** no finding is produced (inherits default `__init__`)
+
+**Given** a class with `__init__(self, *args, **kwargs)` only (pass-through)
+**When** enrichment runs and default config excludes `*args`/`**kwargs`
+**Then** no finding is produced (all params excluded)
+
+**Given** `require-init-params = false` in config
+**When** enrichment runs
+**Then** the rule is skipped entirely
+
+**Given** the `undocumented-init-params` rule is implemented and tested
+**When** the story is marked done
+**Then** a rule reference page exists in `docs/rules/` and is registered in `docs/rules.yml` following the existing pattern


### PR DESCRIPTION
Multi-style enrichment expansion epics sourced from running docvet against boto3 (most downloaded PyPI package) and party-mode consensus (2026-03-07). Epic 34 adds Sphinx/RST docstring style support as the architectural foundation; Epic 35 adds 6 new enrichment rules filling the darglint vacuum. Sprint status updated to reflect Epic 31 completion and track the 10 new stories.

- Add `epics-multi-style-enrichment.md` with Epics 34 (Multi-Style Support & Foundation Rules, 4 stories) and 35 (Enrichment Depth — Correctness & Completeness Rules, 6 stories)
- Update `sprint-status.yaml`: mark Epic 31 done, add Epics 34-35 with 10 story entries
- Add Epic 31 retrospective document
- Add tech spec for module display name in findings (quick spec)

Test: CI only (planning docs, no code changes)

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Planning artifacts only — no source code changes. Verify sprint-status.yaml is valid YAML and story keys follow the kebab-case convention.

### Related
- Epic 31 retrospective covers dynamic badge, summary flag, and config command
- Epics 34-35 sourced from GitHub issues #320-#329