### PR TITLE
fix(test): move _active_style reset to shared conftest fixture

### DIFF
--- a/tests/unit/checks/conftest.py
+++ b/tests/unit/checks/conftest.py
@@ -1,0 +1,20 @@
+"""Shared fixtures for enrichment check tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_active_style():
+    """Reset module-level _active_style after each test.
+
+    ``check_enrichment()`` sets a module-level ``_active_style`` global
+    before dispatching rules.  Without cleanup, sphinx-mode tests leak
+    into subsequent Google-mode tests when ``pytest-randomly`` reorders
+    across files.
+    """
+    import docvet.checks.enrichment as enrichment_mod
+
+    yield
+    enrichment_mod._active_style = "google"

--- a/tests/unit/checks/test_reverse_enrichment.py
+++ b/tests/unit/checks/test_reverse_enrichment.py
@@ -29,15 +29,6 @@ from docvet.config import EnrichmentConfig
 pytestmark = pytest.mark.unit
 
 
-@pytest.fixture(autouse=True)
-def _reset_active_style():
-    """Reset module-level _active_style after each test."""
-    import docvet.checks.enrichment as enrichment_mod
-
-    yield
-    enrichment_mod._active_style = "google"
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The module-level `_active_style` global in `enrichment.py` leaked across test files when `pytest-randomly` reordered sphinx-mode tests before Google-mode tests, causing intermittent CI failures in `test_missing_return_type.py` and `test_undocumented_init_params.py`.

- Move the autouse `_reset_active_style` fixture from `test_reverse_enrichment.py` to `tests/unit/checks/conftest.py` so all check test files get automatic cleanup
- Remove the duplicate fixture from `test_reverse_enrichment.py`

Test: `uv run pytest tests/unit/ -p randomly --randomly-seed=2274026032 --tb=short`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Verified with the exact failing seed (2274026032) that previously caused 4 failures in `test_missing_return_type.py`.

### Related
Pre-existing flake surfaced by `pytest-randomly` — not introduced by any specific PR.