### PR TITLE
fix(config): address PR #379 review feedback

### DIFF
--- a/src/docvet/config/__init__.py
+++ b/src/docvet/config/__init__.py
@@ -20,9 +20,8 @@ Validation keys in ``_VALID_ENRICHMENT_KEYS`` are kept alphabetically.
 set by the user (for sphinx auto-disable logic).
 
 Provides ``format_config_toml`` and ``format_config_json`` for rendering
-the effective configuration with source annotations. TOML formatting
-is decomposed into ``_fmt_toml_value``, ``_get_annotation``, and
-``_format_toml_section`` helpers to keep individual functions focused.
+the effective configuration with source annotations. Formatting logic
+is delegated to the ``_formatting`` submodule.
 
 Attributes:
     load_config: Load and validate ``[tool.docvet]`` from pyproject.toml.

--- a/src/docvet/config/_formatting.py
+++ b/src/docvet/config/_formatting.py
@@ -14,7 +14,8 @@ Examples:
     from docvet.config import load_config, format_config_toml, get_user_keys
 
     cfg = load_config()
-    print(format_config_toml(cfg, get_user_keys()))
+    user_keys, _ = get_user_keys()
+    print(format_config_toml(cfg, user_keys))
     ```
 """
 
@@ -29,8 +30,9 @@ from . import DocvetConfig, _snake_to_kebab
 def _fmt_toml_value(value: object) -> str:
     """Format a Python value as a TOML literal.
 
-    Handles bool, str, int/float, and list types. List elements are
-    formatted recursively to ensure consistent escaping.
+    Handles bool, str, int/float, and list types.  List elements are
+    formatted recursively to ensure consistent escaping.  Falls back to
+    ``str()`` for unexpected types.
 
     Args:
         value: The Python value to format.
@@ -47,7 +49,7 @@ def _fmt_toml_value(value: object) -> str:
     if isinstance(value, list):
         items = ", ".join(_fmt_toml_value(v) for v in value)
         return f"[{items}]"
-    return str(value)
+    return str(value)  # pragma: no cover – fallback for unexpected types
 
 
 def _get_annotation(


### PR DESCRIPTION
Copilot review on #379 caught two real issues; the third was a false positive.

- Unpack `get_user_keys()` tuple in `_formatting.py` module docstring example
- Update `__init__.py` module docstring to reflect formatting delegation to `_formatting` submodule
- Add `pragma: no cover` on unreachable `str()` fallback in `_fmt_toml_value` (all config values are bool/str/int/float/list)

Test: `uv run pytest`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Trivial docstring and pragma fixes — no logic changes.

### Related
- Follow-up to #379