### PR TITLE
refactor(cli): extract check runners and output pipeline

### DIFF
--- a/src/docvet/cli/__init__.py
+++ b/src/docvet/cli/__init__.py
@@ -3,17 +3,9 @@
 Defines the ``typer.Typer`` app with subcommands for each check layer
 (``presence``, ``enrichment``, ``freshness``, ``coverage``, ``griffe``,
 ``lsp``, ``mcp``), the combined ``check`` entry point, and the
-``config`` introspection command. All check subcommands
-accept positional file arguments (``docvet check src/foo.py``) and the
-``--files`` option, share three-tier verbosity control
-(quiet/default/verbose) via dual-registered ``--verbose`` and
-``-q``/``--quiet`` flags, emit a unified
-``Vetted N files [check] — ...`` summary line on stderr, and support
-``--format json`` for structured machine-readable output. The
-``--summary`` flag adds per-check quality percentages to stderr
-(terminal) or a ``quality`` object to JSON output. Output formatting is
-delegated to :func:`_emit_findings`, which dispatches to the appropriate
-formatter in :mod:`docvet.reporting`.
+``config`` introspection command.  Check runners are in ``_runners``
+and the output pipeline is in ``_output``.  This module retains enums,
+discovery helpers, the app callback, and all typer subcommands.
 
 Examples:
     Run all checks on changed files:
@@ -34,6 +26,9 @@ Examples:
     $ docvet enrichment --all
     ```
 
+Attributes:
+    app: The ``typer.Typer`` application instance.
+
 See Also:
     [`docvet.checks`][]: Public API re-exports for check functions.
     [`docvet.config`][]: Configuration dataclasses loaded by the CLI.
@@ -42,12 +37,12 @@ See Also:
 
 from __future__ import annotations
 
-import ast
+import ast  # noqa: F401 – re-exported for test mocks
 import enum
 import importlib.metadata
 import importlib.util
-import os
-import subprocess
+import os  # noqa: F401 – re-exported for test mocks
+import subprocess  # noqa: F401 – re-exported for test mocks
 import sys
 import time
 from pathlib import Path
@@ -55,13 +50,24 @@ from typing import Annotated
 
 import typer
 
-from docvet.ast_utils import get_documented_symbols
+from docvet.ast_utils import (
+    get_documented_symbols,  # noqa: F401 – re-exported for test mocks
+)
 from docvet.checks import Finding
-from docvet.checks.coverage import check_coverage
-from docvet.checks.enrichment import check_enrichment
-from docvet.checks.freshness import check_freshness_diff, check_freshness_drift
-from docvet.checks.griffe_compat import check_griffe_compat
-from docvet.checks.presence import PresenceStats, check_presence
+from docvet.checks.coverage import (
+    check_coverage,  # noqa: F401 – re-exported for test mocks
+)
+from docvet.checks.enrichment import (
+    check_enrichment,  # noqa: F401 – re-exported for test mocks
+)
+from docvet.checks.freshness import (  # noqa: F401
+    check_freshness_diff,
+    check_freshness_drift,
+)
+from docvet.checks.griffe_compat import (
+    check_griffe_compat,  # noqa: F401 – re-exported for test mocks
+)
+from docvet.checks.presence import PresenceStats, check_presence  # noqa: F401
 from docvet.config import (
     DocvetConfig,
     format_config_json,
@@ -71,16 +77,16 @@ from docvet.config import (
 )
 from docvet.discovery import DiscoveryMode, discover_files
 from docvet.reporting import (
-    CheckQuality,
-    compute_quality,
-    determine_exit_code,
-    format_json,
-    format_markdown,
-    format_quality_summary,
+    CheckQuality,  # noqa: F401 – re-exported for test mocks
+    compute_quality,  # noqa: F401 – re-exported for test mocks
+    determine_exit_code,  # noqa: F401 – re-exported for test mocks
+    format_json,  # noqa: F401 – re-exported for test mocks
+    format_markdown,  # noqa: F401 – re-exported for test mocks
+    format_quality_summary,  # noqa: F401 – re-exported for test mocks
     format_summary,
-    format_terminal,
-    format_verbose_header,
-    write_report,
+    format_terminal,  # noqa: F401 – re-exported for test mocks
+    format_verbose_header,  # noqa: F401 – re-exported for test mocks
+    write_report,  # noqa: F401 – re-exported for test mocks
 )
 
 __all__: list[str] = []
@@ -269,489 +275,21 @@ def _discover_and_handle(
     return discovered
 
 
-def _emit_findings(
-    resolved_fmt: str,
-    all_findings: list[Finding],
-    output_path: str | None,
-    no_color: bool,
-    file_count: int,
-    *,
-    presence_stats: PresenceStats | None = None,
-    min_coverage: float = 0.0,
-    quality: dict[str, CheckQuality] | None = None,
-) -> None:
-    """Write findings to stdout or a file in the resolved format.
-
-    Dispatches to the appropriate formatter based on ``resolved_fmt``.
-    JSON format always emits output (even with zero findings). For
-    non-JSON formats, output is skipped when there are no findings
-    (no file is written and nothing is printed to stdout).
-
-    Args:
-        resolved_fmt: One of ``"terminal"``, ``"markdown"``, or ``"json"``.
-        all_findings: Flattened list of findings across all checks.
-        output_path: File path to write to, or ``None`` for stdout.
-        no_color: Whether to suppress ANSI color in terminal output.
-        file_count: Number of files checked (used by JSON format).
-        presence_stats: Aggregate presence coverage stats for JSON output.
-        min_coverage: Coverage threshold from config for JSON output.
-        quality: Per-check quality data for JSON output, or *None*.
-    """
-    if resolved_fmt == "json":
-        json_output = format_json(
-            all_findings,
-            file_count,
-            presence_stats=presence_stats,
-            min_coverage=min_coverage,
-            quality=quality,
-        )
-        if output_path:
-            Path(output_path).write_text(json_output)
-        else:
-            sys.stdout.write(json_output)
-    elif output_path and all_findings:
-        write_report(all_findings, Path(output_path), fmt=resolved_fmt)
-    elif all_findings:
-        if resolved_fmt == "markdown":
-            sys.stdout.write(format_markdown(all_findings))
-        else:
-            sys.stdout.write(format_terminal(all_findings, no_color=no_color))
-
-
-def _format_coverage_line(stats: PresenceStats, threshold: float) -> str:
-    """Format the verbose coverage status line for stderr.
-
-    Uses :attr:`PresenceStats.percentage` for the coverage calculation.
-
-    Args:
-        stats: Aggregate presence coverage stats.
-        threshold: Minimum coverage threshold (0.0 means no threshold).
-
-    Returns:
-        Formatted coverage line ending with a newline.
-    """
-    pct = stats.percentage
-    if threshold > 0.0:
-        status = "passes" if pct >= threshold else "below"
-        return (
-            f"Docstring coverage: {stats.documented}/{stats.total}"
-            f" symbols ({pct:.1f}%) \u2014 {status} {threshold:.1f}% threshold\n"
-        )
-    return (
-        f"Docstring coverage: {stats.documented}/{stats.total} symbols ({pct:.1f}%)\n"
-    )
-
-
-def _resolve_format(fmt_opt: str | None, output_path: str | None) -> str:
-    """Resolve the output format from CLI options.
-
-    Uses a three-tier precedence chain: explicit ``--format`` first,
-    then ``--output`` implies markdown, then terminal as default.
-
-    Args:
-        fmt_opt: Explicit format option value, or *None*.
-        output_path: Output file path, or *None*.
-
-    Returns:
-        Resolved format string: ``"terminal"``, ``"markdown"``, or ``"json"``.
-    """
-    if fmt_opt is not None:
-        return fmt_opt
-    if output_path is not None:
-        return "markdown"
-    return "terminal"
-
-
-def _output_and_exit(
-    ctx: typer.Context,
-    findings_by_check: dict[str, list[Finding]],
-    config: DocvetConfig,
-    file_count: int,
-    checks: list[str],
-    *,
-    presence_stats: PresenceStats | None = None,
-    check_counts: dict[str, int] | None = None,
-) -> None:
-    """Resolve output options, emit findings, and exit with proper code.
-
-    Implements the unified output pipeline: resolves ``no_color`` from
-    environment and TTY state, optionally prints a verbose header to
-    stderr for multi-check runs, resolves the output format via a
-    three-tier precedence chain (explicit ``--format``, then
-    ``--output`` implies markdown, then terminal default), delegates
-    to :func:`_emit_findings` for format dispatch, and raises
-    ``typer.Exit`` with the appropriate exit code.
-
-    Args:
-        ctx: Typer context carrying global options in ``ctx.obj``.
-        findings_by_check: Findings grouped by check name.
-        config: Loaded docvet configuration.
-        file_count: Number of files that were checked.
-        checks: List of check names that were run.
-        presence_stats: Aggregate presence coverage stats, or *None*
-            when the presence check did not run.
-        check_counts: Per-check item counts for quality computation,
-            or *None* when ``--summary`` is not active.
-
-    Raises:
-        typer.Exit: With code 0 when no fail-on findings, code 1 otherwise.
-    """
-    output_path = ctx.obj.get("output")
-    verbose = ctx.obj.get("verbose", False)
-    quiet = ctx.obj.get("quiet", False)
-    summary = ctx.obj.get("summary", False)
-    fmt_opt = ctx.obj.get("format")
-
-    # 1. Resolve no_color
-    no_color = (
-        os.environ.get("NO_COLOR", "") != ""
-        or not sys.stdout.isatty()
-        or output_path is not None
-    )
-
-    # 2. Flatten findings
-    all_findings: list[Finding] = []
-    for findings in findings_by_check.values():
-        all_findings.extend(findings)
-
-    # 3. Verbose header to stderr (only for multi-check runs)
-    if verbose and not quiet and len(checks) > 1:
-        sys.stderr.write(format_verbose_header(file_count, checks))
-
-    # 4. Verbose coverage line
-    if verbose and not quiet and presence_stats is not None:
-        sys.stderr.write(
-            _format_coverage_line(presence_stats, config.presence.min_coverage)
-        )
-
-    # 5. Compute quality if --summary and counts available
-    quality = None
-    if summary and check_counts is not None:
-        quality = compute_quality(findings_by_check, check_counts)
-
-    # 6. Resolve format, emit findings, exit
-    resolved_fmt = _resolve_format(fmt_opt, output_path)
-    _emit_findings(
-        resolved_fmt,
-        all_findings,
-        output_path,
-        no_color,
-        file_count,
-        presence_stats=presence_stats,
-        min_coverage=config.presence.min_coverage,
-        quality=quality if resolved_fmt == "json" else None,
-    )
-
-    # 7. Quality summary to stderr (after findings, before exit)
-    if summary and not quiet and quality is not None:
-        sys.stderr.write(format_quality_summary(quality))
-
-    raise typer.Exit(
-        determine_exit_code(findings_by_check, config, presence_stats=presence_stats)
-    )
-
-
-def _get_git_diff(
-    file_path: Path,
-    project_root: Path,
-    discovery_mode: DiscoveryMode,
-) -> str:
-    """Get git diff output for a single file.
-
-    Runs the appropriate ``git diff`` variant based on the discovery
-    mode and returns the raw unified diff output.
-
-    Args:
-        file_path: Absolute path to the file.
-        project_root: Project root for git working directory.
-        discovery_mode: Controls which git diff variant to run.
-
-    Returns:
-        Raw unified diff output string. Returns an empty string if
-        the git command exits with a non-zero status.
-    """
-    if discovery_mode is DiscoveryMode.STAGED:
-        args = ["git", "diff", "--cached", "--", str(file_path)]
-    elif discovery_mode is DiscoveryMode.ALL:
-        args = ["git", "diff", "HEAD", "--", str(file_path)]
-    else:
-        args = ["git", "diff", "--", str(file_path)]
-
-    result = subprocess.run(
-        args,
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=project_root,
-    )
-    if result.returncode != 0:
-        return ""
-    return result.stdout
-
-
-def _get_git_blame(file_path: Path, project_root: Path) -> str:
-    """Get git blame porcelain output for a single file.
-
-    Runs ``git blame --line-porcelain`` and returns the raw output
-    for drift/age analysis.
-
-    Args:
-        file_path: Absolute path to the file.
-        project_root: Project root for git working directory.
-
-    Returns:
-        Raw porcelain blame output string. Returns an empty string
-        if the git command exits with a non-zero status.
-    """
-    result = subprocess.run(
-        ["git", "blame", "--line-porcelain", "--", str(file_path)],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=project_root,
-    )
-    if result.returncode != 0:
-        return ""
-    return result.stdout
-
-
-# ---------------------------------------------------------------------------
-# Private check runners
-# ---------------------------------------------------------------------------
-
-
-def _write_timing(
-    name: str,
-    file_count: int,
-    elapsed: float,
-    *,
-    verbose: bool,
-    quiet: bool,
-    enabled: bool = True,
-) -> None:
-    """Write a per-check timing line to stderr when verbose.
-
-    Args:
-        name: Check name (e.g. ``"enrichment"``).
-        file_count: Number of files that were checked.
-        elapsed: Elapsed time in seconds.
-        verbose: Whether verbose mode is active.
-        quiet: Whether quiet mode is active.
-        enabled: Extra gate — set to *False* to suppress output
-            (used for griffe when not installed).
-    """
-    if enabled and verbose and not quiet:
-        sys.stderr.write(f"{name}: {file_count} files in {elapsed:.1f}s\n")
-
-
-def _run_enrichment(
-    files: list[Path],
-    config: DocvetConfig,
-    *,
-    show_progress: bool = False,
-) -> tuple[list[Finding], int]:
-    """Run the enrichment check on discovered files.
-
-    Reads each file, parses its AST, and runs all enabled enrichment
-    rules. Passes ``config.docstring_style`` to the enrichment checker
-    for style-aware section detection and rule gating. Files that fail
-    to parse are skipped with a warning.
-
-    Args:
-        files: Discovered Python file paths.
-        config: Loaded docvet configuration.
-        show_progress: Display a progress bar on stderr.
-
-    Returns:
-        A tuple of ``(findings, symbol_count)`` where *symbol_count*
-        is the total documented symbols analyzed across all files.
-    """
-    all_findings: list[Finding] = []
-    symbol_count = 0
-    with typer.progressbar(
-        files, label="enrichment", file=sys.stderr, hidden=not show_progress
-    ) as progress:
-        for file_path in progress:
-            source = file_path.read_text(encoding="utf-8")
-            try:
-                tree = ast.parse(source, filename=str(file_path))
-            except SyntaxError:
-                typer.echo(f"warning: {file_path}: failed to parse, skipping", err=True)
-                continue
-            symbol_count += len(get_documented_symbols(tree))
-            findings = check_enrichment(
-                source,
-                tree,
-                config.enrichment,
-                str(file_path),
-                style=config.docstring_style,
-            )
-            all_findings.extend(findings)
-    return all_findings, symbol_count
-
-
-def _run_presence(
-    files: list[Path],
-    config: DocvetConfig,
-    *,
-    show_progress: bool = False,
-) -> tuple[list[Finding], PresenceStats]:
-    """Run the presence check on discovered files.
-
-    Reads each file, parses its AST, and checks for missing docstrings.
-    Files that fail to parse are skipped with a warning. Aggregates
-    per-file coverage statistics into a single :class:`PresenceStats`.
-
-    Args:
-        files: Discovered Python file paths.
-        config: Loaded docvet configuration.
-        show_progress: Display a progress bar on stderr.
-
-    Returns:
-        A tuple of ``(findings, stats)`` where *findings* is a list of
-        presence findings and *stats* is the aggregate coverage across
-        all files.
-    """
-    all_findings: list[Finding] = []
-    total_documented = 0
-    total_total = 0
-    with typer.progressbar(
-        files, label="presence", file=sys.stderr, hidden=not show_progress
-    ) as progress:
-        for file_path in progress:
-            source = file_path.read_text(encoding="utf-8")
-            try:
-                ast.parse(source, filename=str(file_path))
-            except SyntaxError:
-                typer.echo(f"warning: {file_path}: failed to parse, skipping", err=True)
-                continue
-            findings, stats = check_presence(source, str(file_path), config.presence)
-            all_findings.extend(findings)
-            total_documented += stats.documented
-            total_total += stats.total
-    return all_findings, PresenceStats(documented=total_documented, total=total_total)
-
-
-def _run_freshness(
-    files: list[Path],
-    config: DocvetConfig,
-    freshness_mode: FreshnessMode = FreshnessMode.DIFF,
-    discovery_mode: DiscoveryMode = DiscoveryMode.DIFF,
-    *,
-    show_progress: bool = False,
-) -> tuple[list[Finding], int]:
-    """Run the freshness check on discovered files.
-
-    For diff mode, reads each file, parses the AST, obtains its git
-    diff, and calls ``check_freshness_diff``. For drift mode, reads
-    each file, parses the AST, runs ``git blame --line-porcelain``,
-    and calls ``check_freshness_drift``.
-
-    Args:
-        files: Discovered Python file paths.
-        config: Loaded docvet configuration.
-        freshness_mode: The freshness check strategy (diff or drift).
-        discovery_mode: Controls which git diff variant to run.
-        show_progress: Display a progress bar on stderr.
-
-    Returns:
-        A tuple of ``(findings, symbol_count)`` where *symbol_count*
-        is the total documented symbols analyzed across all files.
-    """
-    if freshness_mode is not FreshnessMode.DIFF:
-        all_findings: list[Finding] = []
-        symbol_count = 0
-        with typer.progressbar(
-            files, label="freshness", file=sys.stderr, hidden=not show_progress
-        ) as progress:
-            for file_path in progress:
-                source = file_path.read_text(encoding="utf-8")
-                try:
-                    tree = ast.parse(source, filename=str(file_path))
-                except SyntaxError:
-                    typer.echo(
-                        f"warning: {file_path}: failed to parse, skipping", err=True
-                    )
-                    continue
-                symbol_count += len(get_documented_symbols(tree))
-                blame_output = _get_git_blame(file_path, config.project_root)
-                findings = check_freshness_drift(
-                    str(file_path), blame_output, tree, config.freshness
-                )
-                all_findings.extend(findings)
-        return all_findings, symbol_count
-
-    all_findings: list[Finding] = []
-    symbol_count = 0
-    with typer.progressbar(
-        files, label="freshness", file=sys.stderr, hidden=not show_progress
-    ) as progress:
-        for file_path in progress:
-            source = file_path.read_text(encoding="utf-8")
-            try:
-                tree = ast.parse(source, filename=str(file_path))
-            except SyntaxError:
-                typer.echo(f"warning: {file_path}: failed to parse, skipping", err=True)
-                continue
-            symbol_count += len(get_documented_symbols(tree))
-            diff_output = _get_git_diff(file_path, config.project_root, discovery_mode)
-            findings = check_freshness_diff(str(file_path), diff_output, tree)
-            all_findings.extend(findings)
-    return all_findings, symbol_count
-
-
-def _run_coverage(files: list[Path], config: DocvetConfig) -> tuple[list[Finding], int]:
-    """Run the coverage check on discovered files.
-
-    Resolves the source root from configuration and checks all discovered
-    files for missing ``__init__.py`` in parent directories.
-
-    Args:
-        files: Discovered Python file paths.
-        config: Loaded docvet configuration.
-
-    Returns:
-        A tuple of ``(findings, package_count)`` where *package_count*
-        is the number of unique package directories scanned.
-    """
-    src_root = config.project_root / config.src_root
-    package_count = len({f.parent for f in files})
-    return check_coverage(src_root, files), package_count
-
-
-def _run_griffe(
-    files: list[Path],
-    config: DocvetConfig,
-    *,
-    verbose: bool = False,
-    quiet: bool = False,
-) -> tuple[list[Finding], int]:
-    """Run the griffe compatibility check on discovered files.
-
-    Checks if griffe is installed, resolves the source root from
-    configuration, and runs ``check_griffe_compat``.
-
-    Args:
-        files: Discovered Python file paths.
-        config: Loaded docvet configuration.
-        verbose: Whether verbose mode is enabled.
-        quiet: Whether quiet mode is enabled.
-
-    Returns:
-        A tuple of ``(findings, file_count)`` where *file_count*
-        is the number of files checked by griffe.
-    """
-    if importlib.util.find_spec("griffe") is None:
-        if "griffe" in config.fail_on:
-            typer.echo("warning: griffe check skipped (griffe not installed)", err=True)
-        elif verbose and not quiet:
-            typer.echo("griffe: skipped (griffe not installed)", err=True)
-        return [], 0
-    src_root = config.project_root / config.src_root
-    if not src_root.is_dir():
-        return [], 0
-    return check_griffe_compat(src_root, files), len(files)
-
+from ._output import (  # noqa: E402
+    _format_coverage_line,  # noqa: F401 – re-exported for tests
+    _output_and_exit,
+    _resolve_format,  # noqa: F401 – re-exported for tests
+)
+from ._runners import (  # noqa: E402
+    _get_git_blame,  # noqa: F401 – re-exported for tests
+    _get_git_diff,  # noqa: F401 – re-exported for tests
+    _run_coverage,
+    _run_enrichment,
+    _run_freshness,
+    _run_griffe,
+    _run_presence,
+    _write_timing,
+)
 
 # ---------------------------------------------------------------------------
 # App callback (global options)

--- a/src/docvet/cli/_output.py
+++ b/src/docvet/cli/_output.py
@@ -1,0 +1,215 @@
+"""CLI output pipeline — format dispatch, coverage lines, and exit logic.
+
+Handles the unified output pipeline for all CLI commands: resolves
+output format, dispatches to formatters, writes quality summaries,
+and exits with appropriate codes.
+
+See Also:
+    [`docvet.cli`][]: CLI application and subcommands.
+    [`docvet.reporting`][]: Report formatters consumed by the pipeline.
+
+Examples:
+    The output pipeline is invoked by each CLI subcommand:
+
+    ```python
+    _output_and_exit(ctx, findings_by_check, config, file_count, checks)
+    ```
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import typer
+
+import docvet.cli as _cli_pkg
+from docvet.checks import Finding
+from docvet.checks.presence import PresenceStats
+from docvet.config import DocvetConfig
+from docvet.reporting import CheckQuality
+
+
+def _emit_findings(
+    resolved_fmt: str,
+    all_findings: list[Finding],
+    output_path: str | None,
+    no_color: bool,
+    file_count: int,
+    *,
+    presence_stats: PresenceStats | None = None,
+    min_coverage: float = 0.0,
+    quality: dict[str, CheckQuality] | None = None,
+) -> None:
+    """Write findings to stdout or a file in the resolved format.
+
+    Dispatches to the appropriate formatter based on ``resolved_fmt``.
+    JSON format always emits output (even with zero findings). For
+    non-JSON formats, output is skipped when there are no findings
+    (no file is written and nothing is printed to stdout).
+
+    Args:
+        resolved_fmt: One of ``"terminal"``, ``"markdown"``, or ``"json"``.
+        all_findings: Flattened list of findings across all checks.
+        output_path: File path to write to, or ``None`` for stdout.
+        no_color: Whether to suppress ANSI color in terminal output.
+        file_count: Number of files checked (used by JSON format).
+        presence_stats: Aggregate presence coverage stats for JSON output.
+        min_coverage: Coverage threshold from config for JSON output.
+        quality: Per-check quality data for JSON output, or *None*.
+    """
+    if resolved_fmt == "json":
+        json_output = _cli_pkg.format_json(
+            all_findings,
+            file_count,
+            presence_stats=presence_stats,
+            min_coverage=min_coverage,
+            quality=quality,
+        )
+        if output_path:
+            Path(output_path).write_text(json_output)
+        else:
+            sys.stdout.write(json_output)
+    elif output_path and all_findings:
+        _cli_pkg.write_report(all_findings, Path(output_path), fmt=resolved_fmt)
+    elif all_findings:
+        if resolved_fmt == "markdown":
+            sys.stdout.write(_cli_pkg.format_markdown(all_findings))
+        else:
+            sys.stdout.write(_cli_pkg.format_terminal(all_findings, no_color=no_color))
+
+
+def _format_coverage_line(stats: PresenceStats, threshold: float) -> str:
+    """Format the verbose coverage status line for stderr.
+
+    Uses :attr:`PresenceStats.percentage` for the coverage calculation.
+
+    Args:
+        stats: Aggregate presence coverage stats.
+        threshold: Minimum coverage threshold (0.0 means no threshold).
+
+    Returns:
+        Formatted coverage line ending with a newline.
+    """
+    pct = stats.percentage
+    if threshold > 0.0:
+        status = "passes" if pct >= threshold else "below"
+        return (
+            f"Docstring coverage: {stats.documented}/{stats.total}"
+            f" symbols ({pct:.1f}%) \u2014 {status} {threshold:.1f}% threshold\n"
+        )
+    return (
+        f"Docstring coverage: {stats.documented}/{stats.total} symbols ({pct:.1f}%)\n"
+    )
+
+
+def _resolve_format(fmt_opt: str | None, output_path: str | None) -> str:
+    """Resolve the output format from CLI options.
+
+    Uses a three-tier precedence chain: explicit ``--format`` first,
+    then ``--output`` implies markdown, then terminal as default.
+
+    Args:
+        fmt_opt: Explicit format option value, or *None*.
+        output_path: Output file path, or *None*.
+
+    Returns:
+        Resolved format string: ``"terminal"``, ``"markdown"``, or ``"json"``.
+    """
+    if fmt_opt is not None:
+        return fmt_opt
+    if output_path is not None:
+        return "markdown"
+    return "terminal"
+
+
+def _output_and_exit(
+    ctx: typer.Context,
+    findings_by_check: dict[str, list[Finding]],
+    config: DocvetConfig,
+    file_count: int,
+    checks: list[str],
+    *,
+    presence_stats: PresenceStats | None = None,
+    check_counts: dict[str, int] | None = None,
+) -> None:
+    """Resolve output options, emit findings, and exit with proper code.
+
+    Implements the unified output pipeline: resolves ``no_color`` from
+    environment and TTY state, optionally prints a verbose header to
+    stderr for multi-check runs, resolves the output format via a
+    three-tier precedence chain (explicit ``--format``, then
+    ``--output`` implies markdown, then terminal default), delegates
+    to :func:`_emit_findings` for format dispatch, and raises
+    ``typer.Exit`` with the appropriate exit code.
+
+    Args:
+        ctx: Typer context carrying global options in ``ctx.obj``.
+        findings_by_check: Findings grouped by check name.
+        config: Loaded docvet configuration.
+        file_count: Number of files that were checked.
+        checks: List of check names that were run.
+        presence_stats: Aggregate presence coverage stats, or *None*
+            when the presence check did not run.
+        check_counts: Per-check item counts for quality computation,
+            or *None* when ``--summary`` is not active.
+
+    Raises:
+        typer.Exit: With code 0 when no fail-on findings, code 1 otherwise.
+    """
+    output_path = ctx.obj.get("output")
+    verbose = ctx.obj.get("verbose", False)
+    quiet = ctx.obj.get("quiet", False)
+    summary = ctx.obj.get("summary", False)
+    fmt_opt = ctx.obj.get("format")
+
+    # 1. Resolve no_color
+    no_color = (
+        os.environ.get("NO_COLOR", "") != ""
+        or not sys.stdout.isatty()
+        or output_path is not None
+    )
+
+    # 2. Flatten findings
+    all_findings: list[Finding] = []
+    for findings in findings_by_check.values():
+        all_findings.extend(findings)
+
+    # 3. Verbose header to stderr (only for multi-check runs)
+    if verbose and not quiet and len(checks) > 1:
+        sys.stderr.write(_cli_pkg.format_verbose_header(file_count, checks))
+
+    # 4. Verbose coverage line
+    if verbose and not quiet and presence_stats is not None:
+        sys.stderr.write(
+            _format_coverage_line(presence_stats, config.presence.min_coverage)
+        )
+
+    # 5. Compute quality if --summary and counts available
+    quality = None
+    if summary and check_counts is not None:
+        quality = _cli_pkg.compute_quality(findings_by_check, check_counts)
+
+    # 6. Resolve format, emit findings, exit
+    resolved_fmt = _resolve_format(fmt_opt, output_path)
+    _emit_findings(
+        resolved_fmt,
+        all_findings,
+        output_path,
+        no_color,
+        file_count,
+        presence_stats=presence_stats,
+        min_coverage=config.presence.min_coverage,
+        quality=quality if resolved_fmt == "json" else None,
+    )
+
+    # 7. Quality summary to stderr (after findings, before exit)
+    if summary and not quiet and quality is not None:
+        sys.stderr.write(_cli_pkg.format_quality_summary(quality))
+
+    raise typer.Exit(
+        _cli_pkg.determine_exit_code(
+            findings_by_check, config, presence_stats=presence_stats
+        )
+    )

--- a/src/docvet/cli/_runners.py
+++ b/src/docvet/cli/_runners.py
@@ -1,0 +1,338 @@
+"""CLI check runners and git helpers.
+
+Each ``_run_*`` function reads files, invokes the corresponding check
+module, and returns findings.  Git helpers (``_get_git_diff``,
+``_get_git_blame``) provide raw VCS data for the freshness runner.
+
+See Also:
+    [`docvet.cli`][]: CLI application and subcommands.
+    [`docvet.checks`][]: Check modules invoked by runners.
+
+Examples:
+    Run the enrichment check on a file list:
+
+    ```python
+    findings, count = _run_enrichment(files, config)
+    ```
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import typer
+
+import docvet.cli as _cli_pkg
+from docvet.checks import Finding
+from docvet.checks.presence import PresenceStats
+from docvet.config import DocvetConfig
+
+from . import DiscoveryMode, FreshnessMode
+
+
+def _get_git_diff(
+    file_path: Path,
+    project_root: Path,
+    discovery_mode: DiscoveryMode,
+) -> str:
+    """Get git diff output for a single file.
+
+    Runs the appropriate ``git diff`` variant based on the discovery
+    mode and returns the raw unified diff output.
+
+    Args:
+        file_path: Absolute path to the file.
+        project_root: Project root for git working directory.
+        discovery_mode: Controls which git diff variant to run.
+
+    Returns:
+        Raw unified diff output string. Returns an empty string if
+        the git command exits with a non-zero status.
+    """
+    if discovery_mode is DiscoveryMode.STAGED:
+        args = ["git", "diff", "--cached", "--", str(file_path)]
+    elif discovery_mode is DiscoveryMode.ALL:
+        args = ["git", "diff", "HEAD", "--", str(file_path)]
+    else:
+        args = ["git", "diff", "--", str(file_path)]
+
+    result = _cli_pkg.subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=project_root,
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def _get_git_blame(file_path: Path, project_root: Path) -> str:
+    """Get git blame porcelain output for a single file.
+
+    Runs ``git blame --line-porcelain`` and returns the raw output
+    for drift/age analysis.
+
+    Args:
+        file_path: Absolute path to the file.
+        project_root: Project root for git working directory.
+
+    Returns:
+        Raw porcelain blame output string. Returns an empty string
+        if the git command exits with a non-zero status.
+    """
+    result = _cli_pkg.subprocess.run(
+        ["git", "blame", "--line-porcelain", "--", str(file_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=project_root,
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Private check runners
+# ---------------------------------------------------------------------------
+
+
+def _write_timing(
+    name: str,
+    file_count: int,
+    elapsed: float,
+    *,
+    verbose: bool,
+    quiet: bool,
+    enabled: bool = True,
+) -> None:
+    """Write a per-check timing line to stderr when verbose.
+
+    Args:
+        name: Check name (e.g. ``"enrichment"``).
+        file_count: Number of files that were checked.
+        elapsed: Elapsed time in seconds.
+        verbose: Whether verbose mode is active.
+        quiet: Whether quiet mode is active.
+        enabled: Extra gate — set to *False* to suppress output
+            (used for griffe when not installed).
+    """
+    if enabled and verbose and not quiet:
+        sys.stderr.write(f"{name}: {file_count} files in {elapsed:.1f}s\n")
+
+
+def _run_enrichment(
+    files: list[Path],
+    config: DocvetConfig,
+    *,
+    show_progress: bool = False,
+) -> tuple[list[Finding], int]:
+    """Run the enrichment check on discovered files.
+
+    Reads each file, parses its AST, and runs all enabled enrichment
+    rules. Passes ``config.docstring_style`` to the enrichment checker
+    for style-aware section detection and rule gating. Files that fail
+    to parse are skipped with a warning.
+
+    Args:
+        files: Discovered Python file paths.
+        config: Loaded docvet configuration.
+        show_progress: Display a progress bar on stderr.
+
+    Returns:
+        A tuple of ``(findings, symbol_count)`` where *symbol_count*
+        is the total documented symbols analyzed across all files.
+    """
+    all_findings: list[Finding] = []
+    symbol_count = 0
+    with typer.progressbar(
+        files, label="enrichment", file=sys.stderr, hidden=not show_progress
+    ) as progress:
+        for file_path in progress:
+            source = file_path.read_text(encoding="utf-8")
+            try:
+                tree = _cli_pkg.ast.parse(source, filename=str(file_path))
+            except SyntaxError:
+                typer.echo(f"warning: {file_path}: failed to parse, skipping", err=True)
+                continue
+            symbol_count += len(_cli_pkg.get_documented_symbols(tree))
+            findings = _cli_pkg.check_enrichment(
+                source,
+                tree,
+                config.enrichment,
+                str(file_path),
+                style=config.docstring_style,
+            )
+            all_findings.extend(findings)
+    return all_findings, symbol_count
+
+
+def _run_presence(
+    files: list[Path],
+    config: DocvetConfig,
+    *,
+    show_progress: bool = False,
+) -> tuple[list[Finding], PresenceStats]:
+    """Run the presence check on discovered files.
+
+    Reads each file, parses its AST, and checks for missing docstrings.
+    Files that fail to parse are skipped with a warning. Aggregates
+    per-file coverage statistics into a single :class:`PresenceStats`.
+
+    Args:
+        files: Discovered Python file paths.
+        config: Loaded docvet configuration.
+        show_progress: Display a progress bar on stderr.
+
+    Returns:
+        A tuple of ``(findings, stats)`` where *findings* is a list of
+        presence findings and *stats* is the aggregate coverage across
+        all files.
+    """
+    all_findings: list[Finding] = []
+    total_documented = 0
+    total_total = 0
+    with typer.progressbar(
+        files, label="presence", file=sys.stderr, hidden=not show_progress
+    ) as progress:
+        for file_path in progress:
+            source = file_path.read_text(encoding="utf-8")
+            try:
+                _cli_pkg.ast.parse(source, filename=str(file_path))
+            except SyntaxError:
+                typer.echo(f"warning: {file_path}: failed to parse, skipping", err=True)
+                continue
+            findings, stats = _cli_pkg.check_presence(
+                source, str(file_path), config.presence
+            )
+            all_findings.extend(findings)
+            total_documented += stats.documented
+            total_total += stats.total
+    return all_findings, PresenceStats(documented=total_documented, total=total_total)
+
+
+def _run_freshness(
+    files: list[Path],
+    config: DocvetConfig,
+    freshness_mode: FreshnessMode = FreshnessMode.DIFF,
+    discovery_mode: DiscoveryMode = DiscoveryMode.DIFF,
+    *,
+    show_progress: bool = False,
+) -> tuple[list[Finding], int]:
+    """Run the freshness check on discovered files.
+
+    For diff mode, reads each file, parses the AST, obtains its git
+    diff, and calls ``check_freshness_diff``. For drift mode, reads
+    each file, parses the AST, runs ``git blame --line-porcelain``,
+    and calls ``check_freshness_drift``.
+
+    Args:
+        files: Discovered Python file paths.
+        config: Loaded docvet configuration.
+        freshness_mode: The freshness check strategy (diff or drift).
+        discovery_mode: Controls which git diff variant to run.
+        show_progress: Display a progress bar on stderr.
+
+    Returns:
+        A tuple of ``(findings, symbol_count)`` where *symbol_count*
+        is the total documented symbols analyzed across all files.
+    """
+    if freshness_mode is not FreshnessMode.DIFF:
+        all_findings: list[Finding] = []
+        symbol_count = 0
+        with typer.progressbar(
+            files, label="freshness", file=sys.stderr, hidden=not show_progress
+        ) as progress:
+            for file_path in progress:
+                source = file_path.read_text(encoding="utf-8")
+                try:
+                    tree = _cli_pkg.ast.parse(source, filename=str(file_path))
+                except SyntaxError:
+                    typer.echo(
+                        f"warning: {file_path}: failed to parse, skipping", err=True
+                    )
+                    continue
+                symbol_count += len(_cli_pkg.get_documented_symbols(tree))
+                blame_output = _cli_pkg._get_git_blame(file_path, config.project_root)
+                findings = _cli_pkg.check_freshness_drift(
+                    str(file_path), blame_output, tree, config.freshness
+                )
+                all_findings.extend(findings)
+        return all_findings, symbol_count
+
+    all_findings: list[Finding] = []
+    symbol_count = 0
+    with typer.progressbar(
+        files, label="freshness", file=sys.stderr, hidden=not show_progress
+    ) as progress:
+        for file_path in progress:
+            source = file_path.read_text(encoding="utf-8")
+            try:
+                tree = _cli_pkg.ast.parse(source, filename=str(file_path))
+            except SyntaxError:
+                typer.echo(f"warning: {file_path}: failed to parse, skipping", err=True)
+                continue
+            symbol_count += len(_cli_pkg.get_documented_symbols(tree))
+            diff_output = _cli_pkg._get_git_diff(
+                file_path, config.project_root, discovery_mode
+            )
+            findings = _cli_pkg.check_freshness_diff(str(file_path), diff_output, tree)
+            all_findings.extend(findings)
+    return all_findings, symbol_count
+
+
+def _run_coverage(files: list[Path], config: DocvetConfig) -> tuple[list[Finding], int]:
+    """Run the coverage check on discovered files.
+
+    Resolves the source root from configuration and checks all discovered
+    files for missing ``__init__.py`` in parent directories.
+
+    Args:
+        files: Discovered Python file paths.
+        config: Loaded docvet configuration.
+
+    Returns:
+        A tuple of ``(findings, package_count)`` where *package_count*
+        is the number of unique package directories scanned.
+    """
+    src_root = config.project_root / config.src_root
+    package_count = len({f.parent for f in files})
+    return _cli_pkg.check_coverage(src_root, files), package_count
+
+
+def _run_griffe(
+    files: list[Path],
+    config: DocvetConfig,
+    *,
+    verbose: bool = False,
+    quiet: bool = False,
+) -> tuple[list[Finding], int]:
+    """Run the griffe compatibility check on discovered files.
+
+    Checks if griffe is installed, resolves the source root from
+    configuration, and runs ``check_griffe_compat``.
+
+    Args:
+        files: Discovered Python file paths.
+        config: Loaded docvet configuration.
+        verbose: Whether verbose mode is enabled.
+        quiet: Whether quiet mode is enabled.
+
+    Returns:
+        A tuple of ``(findings, file_count)`` where *file_count*
+        is the number of files checked by griffe.
+    """
+    if importlib.util.find_spec("griffe") is None:
+        if "griffe" in config.fail_on:
+            typer.echo("warning: griffe check skipped (griffe not installed)", err=True)
+        elif verbose and not quiet:
+            typer.echo("griffe: skipped (griffe not installed)", err=True)
+        return [], 0
+    src_root = config.project_root / config.src_root
+    if not src_root.is_dir():
+        return [], 0
+    return _cli_pkg.check_griffe_compat(src_root, files), len(files)


### PR DESCRIPTION
`cli.py` was 1,456 lines — 2.9x the 500-line module size gate. This converts it to a `cli/` package and extracts two self-contained blocks into dedicated submodules.

- Extract output pipeline (`_emit_findings`, `_format_coverage_line`, `_resolve_format`, `_output_and_exit`) to `_output.py` (215 lines)
- Extract git helpers + check runners (`_get_git_diff`, `_get_git_blame`, `_write_timing`, 5 `_run_*` functions) to `_runners.py` (336 lines)
- Reduce `cli/__init__.py` from 1,456 to 994 lines (32% reduction)
- Submodules use `import docvet.cli as _cli_pkg` to access check functions and stdlib modules through the parent package, ensuring 100+ `mocker.patch("docvet.cli.*")` calls in tests work unchanged
- Entry point `docvet.cli:app` resolves unchanged

Test: `uv run pytest` (1,660 tests, zero modifications)

Closes #373

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Types pass (`uv run ty check`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- `import docvet.cli as _cli_pkg` pattern in `_runners.py` and `_output.py` — submodules access all check functions, reporting functions, and stdlib modules (`ast`, `subprocess`) through the parent package so test mocks on `docvet.cli.*` take effect
- `_get_git_diff` and `_get_git_blame` called via `_cli_pkg._get_git_diff` from within `_runners.py` to support test mocking at `docvet.cli._get_git_diff`
- Re-exported symbols with `noqa: F401` in `__init__.py` — needed because tests mock `docvet.cli.check_enrichment`, `docvet.cli.format_terminal`, etc.

### Related
- Continues refactor series: #377-382 (enrichment + config extractions)
- Follow-up: subcommand extraction to bring `__init__.py` under 500 lines